### PR TITLE
feat(updater): show the release notes that were already being fetched

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,6 +901,12 @@
       <progress id="update-progress" hidden max="1000" value="0"></progress>
       <button id="btn-update-action">Download</button>
       <button id="btn-dismiss-update">Dismiss</button>
+      <!-- Last in the DOM so the controls keep the first row and the notes wrap
+           onto their own; collapsed by default so the bar keeps its height. -->
+      <details id="update-notes" hidden>
+        <summary>What's new</summary>
+        <div id="update-notes-body"></div>
+      </details>
     </div>
     <div id="pagination-measure" aria-hidden="true"></div>
     <div id="print-preview" hidden>

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,7 @@ import {
   setPageBreaks,
 } from "./pagination";
 import { getVersion } from "@tauri-apps/api/app";
+import { releaseNotesText } from "./updates";
 import thirdPartyLicenses from "../THIRD_PARTY_LICENSES.md?raw";
 
 // Uncaught errors must be visible, not lost in an invisible console.
@@ -2077,6 +2078,8 @@ function updateConsent(): "yes" | "no" | "unset" {
 /** What `check_for_update` reports. */
 interface UpdateInfo {
   version: string;
+  /** The release body, as typed into GitHub — free text, not to be trusted as
+   * markup. `null` when the release was published without one. */
   notes: string | null;
 }
 
@@ -2099,6 +2102,10 @@ const updateProgress = document.getElementById(
 const updateAction = document.getElementById(
   "btn-update-action",
 ) as HTMLButtonElement;
+const updateNotes = document.getElementById(
+  "update-notes",
+) as HTMLDetailsElement;
+const updateNotesBody = document.getElementById("update-notes-body")!;
 
 /** The offer on screen in THIS window, and how far it has got. */
 let offeredUpdate: UpdateInfo | null = null;
@@ -2143,6 +2150,7 @@ function askUpdateConsent(): Promise<"yes" | "no"> {
 function hideUpdateBar() {
   updateBar.hidden = true;
   updateProgress.hidden = true;
+  updateNotes.hidden = true;
   offeredUpdate = null;
   updateReadyToInstall = false;
 }
@@ -2155,6 +2163,18 @@ function showUpdateOffer(info: UpdateInfo) {
   updateAction.textContent = "Download";
   updateAction.disabled = false;
   updateAction.hidden = false;
+
+  // `textContent`, never `innerHTML`: this string came off the network, and the
+  // one rule that keeps that harmless is that it is never parsed as markup.
+  // Re-collapsed on every offer rather than left as the user last had it: a
+  // disclosure opened for one version would otherwise still be open when a later
+  // check offers the next one, so the bar would arrive at whatever height that
+  // body happens to need instead of the one line it is supposed to start at.
+  const notes = releaseNotesText(info.notes);
+  updateNotesBody.textContent = notes ?? "";
+  updateNotes.open = false;
+  updateNotes.hidden = notes === null;
+
   updateBar.hidden = false;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -887,6 +887,9 @@ html.theme-dark .brand-dark {
   right: 0;
   z-index: 199;
   display: flex;
+  /* So the release notes can take a row of their own without disturbing the
+     controls; nothing else in the bar is wide enough to wrap on its own. */
+  flex-wrap: wrap;
   align-items: center;
   gap: 12px;
   padding: 8px 14px;
@@ -898,6 +901,34 @@ html.theme-dark .brand-dark {
 
 #update-bar #update-text {
   flex: 1;
+}
+
+#update-bar #update-notes[hidden] {
+  display: none;
+}
+
+/* A full-width row of its own, below the controls. */
+#update-bar #update-notes {
+  flex: 0 0 100%;
+}
+
+#update-bar #update-notes summary {
+  cursor: pointer;
+  /* The disclosure is a control among buttons; underlining says so without
+     giving it a border and the visual weight of one. */
+  text-decoration: underline;
+}
+
+/* Capped rather than truncated: a long release body scrolls here instead of
+   pushing the editor up, and nothing is withheld from the user. */
+#update-bar #update-notes-body {
+  max-height: 8.5em;
+  overflow-y: auto;
+  margin-top: 6px;
+  /* The body is displayed as the plain text it is — deliberately not run
+     through markdown-it, which is reserved for document content. */
+  white-space: pre-wrap;
+  font-family: Consolas, monospace;
 }
 
 #update-bar progress {

--- a/src/updates.test.ts
+++ b/src/updates.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { releaseNotesText } from "./updates";
+
+describe("releaseNotesText", () => {
+  it("keeps a real body, so there is something to show", () => {
+    expect(releaseNotesText("- Fixed a crash\n- Faster export")).toBe(
+      "- Fixed a crash\n- Faster export",
+    );
+  });
+
+  it("treats every way of publishing without notes as no notes", () => {
+    // The three shapes that all mean the same thing. The last is what a GitHub
+    // release form returns when the body field is opened and left alone, and it
+    // is the one that would otherwise slip through a plain `if (notes)`.
+    expect(releaseNotesText(null)).toBeNull();
+    expect(releaseNotesText("")).toBeNull();
+    expect(releaseNotesText("  \n\t\r\n ")).toBeNull();
+  });
+
+  it("normalises CRLF, which is what GitHub serves for web-edited bodies", () => {
+    // Displayed with white-space: pre-wrap, where a surviving CR is a rendered
+    // character rather than a line break.
+    expect(releaseNotesText("one\r\ntwo\rthree")).toBe("one\ntwo\nthree");
+  });
+
+  it("trims surrounding blank lines without touching the body's own shape", () => {
+    expect(releaseNotesText("\n\n# Heading\n\nbody\n\n")).toBe(
+      "# Heading\n\nbody",
+    );
+  });
+});

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure helpers for the update offer.
+ *
+ * ## Why this is its own module
+ *
+ * The updater's moving parts live in `main.ts` because they are inseparable from
+ * the DOM and from `invoke` — there is nothing to test in a button that calls a
+ * Tauri command. What *is* testable is the handful of decisions made about
+ * values that arrive from a remote host, and those are the ones worth pinning:
+ * the release body comes from whatever text somebody typed into a GitHub release
+ * form, so "what counts as no notes at all" is a real question with a wrong
+ * answer, not a formality.
+ */
+
+/**
+ * The release body as it should be displayed, or `null` when there is nothing to
+ * show.
+ *
+ * Three shapes all mean "this release was published without notes" and all have
+ * to collapse to the same `null`: the field absent (`null` from Rust's
+ * `Option<String>`), the empty string, and a body of nothing but whitespace —
+ * which is what a GitHub release form returns when someone opens the body field
+ * and leaves it. Rendering an empty "What's new" disclosure for any of them
+ * offers the user a control that reveals nothing.
+ *
+ * Newlines are normalised because the body is displayed with `white-space:
+ * pre-wrap`, where a stray CR is a rendered character rather than a line break.
+ * GitHub serves CRLF for anything edited through the web form.
+ */
+export function releaseNotesText(notes: string | null): string | null {
+  if (notes === null) return null;
+  const normalised = notes.replace(/\r\n?/g, "\n").trim();
+  return normalised === "" ? null : normalised;
+}


### PR DESCRIPTION
## What & why

Closes #2.

`check_for_update` has always returned the release body — `UpdateInfo.notes` is
populated at `src-tauri/src/lib.rs:567` and typed at `src/main.ts:2080` — and
nothing ever read it. The offer bar said `Monoleaf 1.0.1 is available.` and
stopped, so the user was asked to accept an installer with no way to find out
what was in it.

This renders it in a collapsed `<details>` below the controls.

**Why collapsed and in-bar.** The bar is deliberately not a modal ("an update is
never more urgent than what the user is typing", `index.html:897`). A bar that
grows to three lines on its own is halfway back to being one, so it stays one
line until asked. `#update-bar` gains `flex-wrap` so the notes take a row of
their own without disturbing the controls, and the body is capped at `8.5em`
with its own scrollbar — a long release scrolls rather than pushing the editor
up the screen, and nothing is truncated.

**Why `textContent` and not markdown-it.** The string arrives from a remote
host. The rule that keeps that harmless is that it is never parsed as markup;
markdown-it stays reserved for document content. Plain text in `pre-wrap` is
what these bodies actually are.

**Why a new module for four lines.** "Published without notes" has three
spellings that have to collapse to one: `null` from Rust's `Option<String>`, the
empty string, and a body of nothing but whitespace — which is what the GitHub
release form returns when someone opens the field and leaves it. Any of the
three rendering an empty "What's new" offers a control that reveals nothing.
`releaseNotesText` also normalises CRLF, which GitHub serves for web-edited
bodies and which `pre-wrap` renders as a character rather than a line break.
That is four cases worth a test, and `main.ts` has no test file.

## Checklist

- [ ] `npm test` passes
- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] For Rust changes: n/a — no Rust changed
- [x] The byte-for-byte round-trip guarantee still holds (no lossy load/save)
- [x] New in-file constructs degrade gracefully in a plain-Markdown viewer — n/a,
      nothing here touches the `.md`

> **The four unchecked boxes are not "not verified by me", they are "not
> verifiable on the machine I wrote this on"** — it has no Node and no Rust
> toolchain, so `npm`, `npx` and `cargo` do not exist there. `build.yml` runs the
> full gate on every pull request, so CI is the check. Please don't read the
> unchecked boxes as a claim that they pass; read them as a claim that nobody has
> looked yet. Happy to have them confirmed green before you spend time reviewing.

## Notes for reviewers

- **Merge order.** #3, #4 and #5 also touch `src/main.ts:2058-2320` and two of
  them extend `src/updates.ts`. They're separate PRs so you can take them
  independently, but whichever merges second will need a rebase. This one is the
  smallest and the most self-contained, so it's the cheapest to take first.
- **Two judgement calls worth overruling if you disagree.** The disclosure
  re-collapses on every offer, so a details left open for 1.0.1 doesn't make the
  bar arrive pre-expanded when 1.0.2 shows up. And the summary is underlined
  rather than bordered, so it reads as a control next to two real buttons without
  competing with them.
- **Not done:** markdown rendering of the body. Deferred rather than rejected —
  worth revisiting if release bodies get long enough that plain text reads badly,
  but it means putting remote text through the document pipeline, which felt like
  a bigger decision than this PR should make on its own.
- No screenshot: I can't build the app on this machine. The layout change is
  `flex-wrap` plus a `flex: 0 0 100%` child, so it's inert until `notes` is
  non-empty — a release published without a body renders exactly today's bar.
