### PR TITLE
feat(updater): let the user decline one version without declining all of them

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,6 +900,16 @@
       <span id="update-text"></span>
       <progress id="update-progress" hidden max="1000" value="0"></progress>
       <button id="btn-update-action">Download</button>
+      <!-- Two ways to say no, because they are two different answers: Dismiss
+           clears the bar and lets the next check offer this version again, Skip
+           records that this version was declined. Neither is a way to turn
+           update checks off — that stays in Settings. -->
+      <button
+        id="btn-skip-update"
+        title="Stop offering this version. A newer release will still be offered."
+      >
+        Skip this version
+      </button>
       <button id="btn-dismiss-update">Dismiss</button>
     </div>
     <div id="pagination-measure" aria-hidden="true"></div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,7 @@ import {
   setPageBreaks,
 } from "./pagination";
 import { getVersion } from "@tauri-apps/api/app";
+import { clearSkippedVersion, isVersionSkipped, skipVersion } from "./updates";
 import thirdPartyLicenses from "../THIRD_PARTY_LICENSES.md?raw";
 
 // Uncaught errors must be visible, not lost in an invisible console.
@@ -2163,14 +2164,26 @@ function showUpdateOffer(info: UpdateInfo) {
  * failures: a click is owed an answer, including "nothing to install", while an
  * automatic check that finds no network stays silent rather than teaching people
  * to dismiss whatever Monoleaf says.
+ *
+ * It now also decides whether a skipped version is honoured. An automatic check
+ * respects the skip, because that is what the user asked for. A click does not:
+ * "Check for updates" is a question about right now, and answering "you are up
+ * to date" when an update exists and is merely declined would be a lie — the one
+ * thing this bar cannot afford to be.
  */
 async function checkForUpdate(userInitiated: boolean) {
   try {
     const info = await invoke<UpdateInfo | null>("check_for_update", {
       userInitiated,
     });
-    if (info !== null) showUpdateOffer(info);
-    else if (userInitiated) {
+    if (info !== null) {
+      if (!userInitiated && isVersionSkipped(info.version)) return;
+      // Cleared before showing, never after: once this version is in the bar,
+      // storage saying it was declined would contradict the screen, and the next
+      // automatic check would hide it again with nothing to explain why.
+      clearSkippedVersion();
+      showUpdateOffer(info);
+    } else if (userInitiated) {
       await uiAlert(`Monoleaf ${await getVersion()} is the latest version.`, {
         title: "No update available",
       });
@@ -2276,6 +2289,29 @@ updateAction.addEventListener("click", () => {
 document
   .getElementById("btn-dismiss-update")!
   .addEventListener("click", hideUpdateBar);
+
+/**
+ * "Not this version" — the answer the bar previously had no way to express.
+ *
+ * Without it the only lasting way to decline a specific version was to switch
+ * update checks off, which declines every future version too and says nothing
+ * about having done so. Dismiss stays what it was, a hide until the next check.
+ *
+ * Rust is told as well, for the same reason `toggleUpdateChecks` tells it: an
+ * update left sitting in `PendingUpdate` keeps `install_update` armed, so a
+ * declined version could still be installed from a stale bar in another window.
+ */
+function skipOfferedVersion() {
+  // Read before `hideUpdateBar`, which clears `offeredUpdate`.
+  const version = offeredUpdate?.version;
+  if (version !== undefined) skipVersion(version);
+  hideUpdateBar();
+  void invoke("discard_pending_update").catch(() => {});
+}
+
+document
+  .getElementById("btn-skip-update")!
+  .addEventListener("click", skipOfferedVersion);
 
 /**
  * The settings toggle. Renders off while consent is unset, because nothing is

--- a/src/styles.css
+++ b/src/styles.css
@@ -913,6 +913,10 @@ html.theme-dark .brand-dark {
   border-radius: 5px;
   padding: 3px 10px;
   cursor: pointer;
+  /* Three buttons now share the row, and #update-text is the only flexible
+     item; without this "Skip this version" wraps to two lines in a narrow
+     window and drags the bar's height with it. */
+  white-space: nowrap;
 }
 
 #update-bar button[disabled] {

--- a/src/updates.test.ts
+++ b/src/updates.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearSkippedVersion,
+  isVersionSkipped,
+  skipVersion,
+  type SkipStorage,
+} from "./updates";
+
+/** A stand-in for localStorage; only the three methods the module uses. */
+function fakeStorage(
+  entries: [string, string][] = [],
+): SkipStorage & { size: () => number } {
+  const map = new Map(entries);
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    size: () => map.size,
+  };
+}
+
+describe("the skip round trip", () => {
+  // The property that matters: a decision made in one session has to be read
+  // back in the next one. If the write and the read ever disagree the failure is
+  // silent, and it is silent in whichever direction hurts.
+  it("reads back exactly the version that was skipped", () => {
+    const storage = fakeStorage();
+    skipVersion("1.0.1", storage);
+    expect(isVersionSkipped("1.0.1", storage)).toBe(true);
+  });
+
+  it("offers nothing back when nothing was skipped", () => {
+    expect(isVersionSkipped("1.0.1", fakeStorage())).toBe(false);
+  });
+});
+
+describe("isVersionSkipped", () => {
+  it("lets a newer version through, so skipping is never permanent", () => {
+    // The whole safety argument for the feature: the stored value is consulted
+    // against the exact version on offer, so the next release is unaffected.
+    const storage = fakeStorage();
+    skipVersion("1.0.1", storage);
+    expect(isVersionSkipped("1.0.2", storage)).toBe(false);
+  });
+
+  it("lets an older version through too", () => {
+    // Not an oversight. An equality test answers "did you decline this?", which
+    // is the question asked. An ordering test would answer "is this newer than
+    // what you declined?" and would wrongly suppress a deliberate downgrade or a
+    // release that was pulled and republished.
+    const storage = fakeStorage();
+    skipVersion("1.0.2", storage);
+    expect(isVersionSkipped("1.0.1", storage)).toBe(false);
+  });
+});
+
+describe("skipVersion", () => {
+  it("keeps one version, so skips cannot accumulate unseen", () => {
+    const storage = fakeStorage();
+    skipVersion("1.0.1", storage);
+    skipVersion("1.0.2", storage);
+    expect(isVersionSkipped("1.0.1", storage)).toBe(false);
+    expect(isVersionSkipped("1.0.2", storage)).toBe(true);
+    expect(storage.size()).toBe(1);
+  });
+
+  it("does not throw when storage refuses the write", () => {
+    // Over quota. The offer coming back at the next check is the right failure;
+    // an exception raised at somebody mid-sentence is not.
+    const full: SkipStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+      removeItem: () => {},
+    };
+    expect(() => skipVersion("1.0.1", full)).not.toThrow();
+  });
+});
+
+describe("clearSkippedVersion", () => {
+  it("makes a skipped version offerable again", () => {
+    // What keeps storage from contradicting the screen: an explicit check can
+    // re-offer a skipped version, and once it is in the bar it must not still be
+    // recorded as declined.
+    const storage = fakeStorage();
+    skipVersion("1.0.1", storage);
+    clearSkippedVersion(storage);
+    expect(isVersionSkipped("1.0.1", storage)).toBe(false);
+  });
+
+  it("is harmless when nothing was skipped", () => {
+    expect(() => clearSkippedVersion(fakeStorage())).not.toThrow();
+  });
+});

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,0 +1,77 @@
+/**
+ * Which version the user has decided not to install.
+ *
+ * ## Why this is its own module
+ *
+ * The updater's moving parts live in `main.ts` because they are inseparable from
+ * the DOM and from `invoke` — there is nothing to test in a button that calls a
+ * Tauri command. This part is different: it is a decision the user made, held in
+ * storage, that has to survive a restart and then be read back correctly. That
+ * round trip is testable, and it is worth testing, because both ways of getting
+ * it wrong are silent. Skip too eagerly and a user stops being offered upgrades
+ * they never declined; skip too weakly and "not this version" quietly means
+ * "ask me again next launch", which is the behaviour this exists to replace.
+ *
+ * Storage is taken as an argument, following `recovery.ts`, so the round trip
+ * can be tested against a fake rather than a browser.
+ *
+ * ## One version, not a set
+ *
+ * The stored value is overwritten by whatever is skipped next and consulted only
+ * against the exact version on offer, so skipping is never permanent: a newer
+ * release always gets through. That is the property that makes this safe to
+ * offer at all. A set of skipped versions would accumulate, and a user who
+ * skipped a few in a row would have no way to tell that they had, or to undo it.
+ */
+
+const SKIPPED_KEY = "monoleaf.update-skipped";
+
+/** The subset of `Storage` this module uses; a plain object satisfies it. */
+export type SkipStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Whether this exact version has been skipped.
+ *
+ * Deliberately an equality test and not a comparison. Version *ordering* would
+ * need a semver parser and would answer a different question — "is this newer
+ * than what I declined" — which sounds equivalent and is not: a release pulled
+ * and republished, or a downgrade offered deliberately, would be suppressed by
+ * an ordering rule and is correctly offered by this one.
+ */
+export function isVersionSkipped(
+  version: string,
+  storage: SkipStorage = localStorage,
+): boolean {
+  return storage.getItem(SKIPPED_KEY) === version;
+}
+
+/**
+ * Record that the user does not want this version.
+ *
+ * Failure is swallowed for the same reason `writeDraft` swallows it: storage
+ * being full is a reason for the offer to come back later, not for the click to
+ * raise an error at somebody mid-sentence.
+ */
+export function skipVersion(
+  version: string,
+  storage: SkipStorage = localStorage,
+): void {
+  try {
+    storage.setItem(SKIPPED_KEY, version);
+  } catch {
+    /* the offer returns at the next check — see above */
+  }
+}
+
+/**
+ * Forget the skip.
+ *
+ * Called whenever an offer is actually put on screen, so the stored decision can
+ * never contradict what the user is looking at. Without this, a version skipped
+ * and then re-offered by an explicit "Check for updates" would sit in the bar
+ * while storage still said it had been declined, and the next automatic check
+ * would hide it again with no way to tell why.
+ */
+export function clearSkippedVersion(storage: SkipStorage = localStorage): void {
+  storage.removeItem(SKIPPED_KEY);
+}


### PR DESCRIPTION
## What & why

Closes #5.

`hideUpdateBar` cleared local state and nothing else, so the next check offered
the same version again. A user who had decided to hold on a release had two ways
to act on that, and both were wrong: leave the bar on screen permanently, or
switch update checks off — which declines every *future* version too, and gives
no sign that that is what just happened. The natural gesture for "not this one"
quietly meant "never tell me again".

## The one place this departs from the issue

The issue proposed repurposing Dismiss and listed two buttons as the
alternative. **This implements the alternative**, because on writing it the
argument reversed: "hide until the next check" and "stop offering this version"
are two different answers, and repurposing the one button would have removed the
first to provide the second. Adding a button is strictly additive — nothing that
worked before behaves differently — and it makes the distinction visible at the
point of decision rather than buried in a tooltip. Easy to fold back to one
button if you'd rather; say the word.

## Design points worth agreeing or overruling

- **Equality, not ordering.** `isVersionSkipped` compares the exact string. That
  answers the question being asked — "did you decline this?" — where an ordering
  rule would answer "is this newer than what you declined?" and would wrongly
  suppress a deliberate downgrade, or a release that was pulled and republished
  under the same tag. It also avoids pulling in a semver parser for one
  comparison.
- **One version, not a set.** A skip is always superseded by the next one, so it
  can never accumulate into a silent opt-out the user can't see or undo.
- **An explicit check ignores the skip.** "Check for updates" is a question about
  right now; replying "you are up to date" when an update exists and is merely
  declined would be a lie, which is the one thing this bar can't afford to be.
  Showing an offer clears the stored skip, so storage never contradicts the
  screen.
- **Skip tells Rust too.** Same reason `toggleUpdateChecks` does
  (`src/main.ts:2294-2297`): an update left in `PendingUpdate` keeps
  `install_update` armed, so a declined version could still be installed from a
  stale bar in another window.

## Checklist

- [ ] `npm test` passes
- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] For Rust changes: n/a — no Rust changed
- [x] The byte-for-byte round-trip guarantee still holds (no lossy load/save)
- [x] New in-file constructs degrade gracefully in a plain-Markdown viewer — n/a,
      nothing here touches the `.md`

> **The unchecked boxes mean "not verifiable on the machine I wrote this on",
> not "verified".** It has no Node and no Rust toolchain, so `npm`, `npx` and
> `cargo` don't exist there. `build.yml` runs the full gate on every PR, so CI is
> the check — please don't read the unchecked boxes as a claim that they pass.

## Notes for reviewers

- **Conflicts with #7.** Both create `src/updates.ts` and `src/updates.test.ts`
  from scratch and both touch the same region of `src/main.ts`. Whichever merges
  second needs a rebase; the resolution is concatenation, since the two sets of
  functions and tests are disjoint. Same for #4 and the multi-window work.
- **A pre-existing race this inherits rather than introduces.** Skipping while a
  download is in flight discards the pending update, so `download_update`
  rejects with "The pending update changed while it was downloading" and the
  handler writes text to an already-hidden bar. Harmless — `offeredUpdate` is
  null, so nothing re-shows it — and it is exactly what switching the setting off
  mid-download already does today. I deliberately didn't fix it here: it belongs
  with whoever decides whether download should be cancellable at all.
- **Not done:** no "remind me in N days". Rejected in the issue — it reintroduces
  the nagging the consent dialog's own design notes argue against, and needs a
  timestamp and a policy where a version string does.
- No screenshot: I can't build the app on this machine. The only layout change is
  a third button in the bar plus `white-space: nowrap` on the shared button rule,
  so "Skip this version" can't wrap to two lines and drag the bar's height with
  it in a narrow window.
