### PR TITLE
feat(updater): keep checking while the app stays open

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,9 +848,9 @@
           id="btn-updates"
           class="menu-row"
           aria-pressed="false"
-          title="Ask github.com once at startup whether a newer version exists. Off means Monoleaf makes no network request of its own at all."
+          title="Ask github.com at startup, and once a day while Monoleaf is open, whether a newer version exists. Off means Monoleaf makes no network request of its own at all."
         >
-          <span>Check for updates at startup</span><span class="switch"></span>
+          <span>Automatic update checks</span><span class="switch"></span>
         </button>
         <div class="menu-sep"></div>
         <button id="btn-name" class="menu-row">

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,7 @@ import {
   setPageBreaks,
 } from "./pagination";
 import { getVersion } from "@tauri-apps/api/app";
+import { RECHECK_POLL_MS, dueForRecheck } from "./updates";
 import thirdPartyLicenses from "../THIRD_PARTY_LICENSES.md?raw";
 
 // Uncaught errors must be visible, not lost in an invisible console.
@@ -2106,6 +2107,13 @@ let updateReadyToInstall = false;
 let updateBusy = false;
 
 /**
+ * When the last check was made, and the tick that decides whether to make
+ * another. `null` until the first check of the session.
+ */
+let lastUpdateCheckAt: number | null = null;
+let recheckTimer: number | undefined;
+
+/**
  * Set for exactly one flush round when the user answers "Don't save" to the
  * install prompt in this window. See `installOfferedUpdate` for why this exists
  * instead of clearing `dirty`, and `setupRecoveryFlush` for what it does.
@@ -2165,6 +2173,10 @@ function showUpdateOffer(info: UpdateInfo) {
  * to dismiss whatever Monoleaf says.
  */
 async function checkForUpdate(userInitiated: boolean) {
+  // Stamped before the request, not after: a check that hangs until the 20s
+  // manifest timeout has still been made, and stamping on the way out would let
+  // every failed check re-arm the next tick to fire immediately.
+  lastUpdateCheckAt = Date.now();
   try {
     const info = await invoke<UpdateInfo | null>("check_for_update", {
       userInitiated,
@@ -2278,6 +2290,41 @@ document
   .addEventListener("click", hideUpdateBar);
 
 /**
+ * Keep checking while the app stays open.
+ *
+ * Monoleaf is left running for days, and one check at startup meant a long
+ * session got one check on the day it began — so the people who had said yes to
+ * being told were the ones least likely to hear anything.
+ *
+ * The tick is short and the interval is long, deliberately: see `RECHECK_POLL_MS`
+ * for why a `setInterval` of a day is the wrong instrument. What arrives here
+ * every half hour is a comparison of two numbers that almost always returns.
+ *
+ * ONE TIMER PER APP, in the main window, matching where the startup check runs.
+ * A per-window timer would multiply one app-global question by however many
+ * documents happened to be open.
+ */
+function startPeriodicUpdateChecks() {
+  if (!isMainWindow || recheckTimer !== undefined) return;
+  recheckTimer = window.setInterval(() => {
+    // Re-read rather than captured: consent can be switched off in another
+    // window, and this timer would otherwise outlive the permission it needs.
+    if (updateConsent() !== "yes") return;
+    // Nothing to gain and a race to lose: a check landing mid-download would
+    // replace the PendingUpdate the download is about to attach bytes to, and
+    // re-offering something already on screen just redraws the bar.
+    if (updateBusy || offeredUpdate !== null) return;
+    if (!dueForRecheck(Date.now(), lastUpdateCheckAt)) return;
+    void checkForUpdate(false);
+  }, RECHECK_POLL_MS);
+}
+
+function stopPeriodicUpdateChecks() {
+  window.clearInterval(recheckTimer);
+  recheckTimer = undefined;
+}
+
+/**
  * The settings toggle. Renders off while consent is unset, because nothing is
  * being checked in that state.
  */
@@ -2290,11 +2337,16 @@ function toggleUpdateChecks() {
     // evidence that the switch did anything, and a switch with no visible effect
     // reads as broken.
     void checkForUpdate(true);
+    startPeriodicUpdateChecks();
   } else {
     // Rust has to forget any downloaded update too, or install-on-click stays
     // armed for a feature the user has just switched off.
     hideUpdateBar();
     void invoke("discard_pending_update").catch(() => {});
+    // Stopped, not left ticking on a consent test. "Off means Monoleaf makes no
+    // network request of its own at all" is a promise in the toggle's own
+    // tooltip, and the cheapest way to keep it is to have nothing running.
+    stopPeriodicUpdateChecks();
   }
   view.focus();
 }
@@ -2316,7 +2368,10 @@ async function startupUpdateFlow() {
     refreshModeButtons();
     view.focus();
   }
-  if (updateConsent() === "yes") await checkForUpdate(false);
+  if (updateConsent() === "yes") {
+    await checkForUpdate(false);
+    startPeriodicUpdateChecks();
+  }
 }
 
 async function startupOpen() {

--- a/src/updates.test.ts
+++ b/src/updates.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { RECHECK_INTERVAL_MS, dueForRecheck } from "./updates";
+
+const HOUR = 60 * 60 * 1000;
+/** An arbitrary fixed "now", so nothing here depends on the wall clock. */
+const NOW = 1_700_000_000_000;
+
+describe("dueForRecheck", () => {
+  it("is not due before the interval has elapsed", () => {
+    expect(dueForRecheck(NOW, NOW - 23 * HOUR)).toBe(false);
+  });
+
+  it("is due once the interval has elapsed", () => {
+    expect(dueForRecheck(NOW, NOW - 25 * HOUR)).toBe(true);
+  });
+
+  it("is due exactly on the boundary", () => {
+    // Stated so the >= is a decision rather than an accident: a check due at
+    // exactly 24h should happen at 24h, not 24h plus one poll.
+    expect(dueForRecheck(NOW, NOW - RECHECK_INTERVAL_MS)).toBe(true);
+  });
+
+  it("is due when nothing has been checked yet", () => {
+    // A window that has somehow never checked should not wait a day to start.
+    expect(dueForRecheck(NOW, null)).toBe(true);
+  });
+
+  it("is due when the clock has moved backwards", () => {
+    // The case this function exists to get right. NTP correcting a badly-set
+    // clock, or a timezone fix, can leave the last-checked stamp in the future.
+    // A naive `now - last >= interval` is false for as long as the skew lasts,
+    // silently disabling checks with nothing to say why.
+    expect(dueForRecheck(NOW, NOW + 100 * HOUR)).toBe(true);
+  });
+
+  it("survives a long suspend, because it compares clocks and not uptime", () => {
+    // A machine closed for a week wakes with a stamp a week old and checks on
+    // the first tick. A setInterval(24h) would still be counting awake time.
+    expect(dueForRecheck(NOW, NOW - 7 * 24 * HOUR)).toBe(true);
+  });
+
+  it("takes the interval as an argument, so the policy is not baked in", () => {
+    expect(dueForRecheck(NOW, NOW - 2 * HOUR, HOUR)).toBe(true);
+    expect(dueForRecheck(NOW, NOW - 2 * HOUR, 3 * HOUR)).toBe(false);
+  });
+});

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,0 +1,63 @@
+/**
+ * When an automatic update check is due.
+ *
+ * ## Why this is its own module
+ *
+ * The updater's moving parts live in `main.ts` because they are inseparable from
+ * the DOM and from `invoke` — there is nothing to test in a button that calls a
+ * Tauri command. The decision of *when* to check is different: it is arithmetic
+ * on two numbers, it has edge cases that only appear on somebody else's machine
+ * (a laptop closed for a week, a clock corrected backwards by NTP), and getting
+ * it wrong fails silently in both directions — too eager means unrequested
+ * network traffic, too slow means the feature quietly does nothing.
+ */
+
+/**
+ * How long between automatic checks.
+ *
+ * A day, because the thing being detected changes on the order of weeks and the
+ * cost of being a few hours late is nil. This is the number to argue about; the
+ * mechanism below does not care what it is.
+ */
+export const RECHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How often the interval is *examined* — which is not how often it fires.
+ *
+ * The check is due-by-wall-clock, not due-by-timer, and these are two different
+ * things on a laptop. A `setInterval` of 24h does not fire 24h after it was set:
+ * it fires after 24h of the machine being awake, so a machine suspended nightly
+ * drifts later every day and one closed for a week does not fire at all until a
+ * week of uptime has accumulated. Comparing timestamps on a short tick sidesteps
+ * that entirely — a resumed machine notices on the first tick after waking.
+ *
+ * Half an hour is small enough that the wait after a resume is not noticeable
+ * and large enough that the tick itself is free: it compares two numbers and,
+ * almost always, returns.
+ */
+export const RECHECK_POLL_MS = 30 * 60 * 1000;
+
+/**
+ * Whether enough time has passed since the last check.
+ *
+ * `lastCheckedAt` is a `Date.now()` stamp, or `null` if no check has happened in
+ * this session yet — which reads as "due", so a window that has somehow never
+ * checked does not wait a day to start.
+ *
+ * A clock that has moved *backwards* also reads as due. This is the case worth
+ * being deliberate about: NTP correcting a badly-set clock, or a user fixing
+ * their timezone, can leave `lastCheckedAt` in the future, and a naive
+ * `now - last >= interval` would then be false for as long as the skew lasts —
+ * silently disabling checks for what could be hours or years, with nothing to
+ * indicate why. Treating it as due costs one extra request in a rare case; the
+ * alternative costs the feature.
+ */
+export function dueForRecheck(
+  now: number,
+  lastCheckedAt: number | null,
+  interval: number = RECHECK_INTERVAL_MS,
+): boolean {
+  if (lastCheckedAt === null) return true;
+  if (now < lastCheckedAt) return true;
+  return now - lastCheckedAt >= interval;
+}


### PR DESCRIPTION
## What & why

Closes #4.

There was exactly one automatic check, at startup (`startupUpdateFlow`). Monoleaf
is a document editor people leave running for days, so a session that lasted a
week got one check, on the day it began — which meant the users who had said yes
to being told were the ones least likely to hear anything.

## The part worth reviewing: this is not `setInterval(24h)`

A 24-hour timer does **not** fire a day after it's set. It fires after a day of
the machine being *awake*. A laptop suspended nightly drifts later every day, and
one closed for a week doesn't fire at all until a week of uptime accumulates.

So what runs is a half-hourly tick (`RECHECK_POLL_MS`) that compares wall-clock
timestamps (`dueForRecheck`). A resumed machine notices on the first tick after
waking. The tick itself is two numbers and a comparison, and almost always
returns immediately.

`dueForRecheck` also treats a clock that has moved **backwards** as due. NTP
correcting a badly-set clock, or a timezone fix, can leave the last-checked stamp
in the future; a plain `now - last >= interval` is then false for as long as the
skew lasts, silently disabling checks for hours or years with nothing to say why.
One extra request in a rare case is the cheaper failure. Both cases are tested.

## Other decisions

- **One timer per app**, in the main window, matching where the startup check
  already runs. A per-window timer would multiply one app-global question by
  however many documents are open.
- **Stopped, not left ticking on a consent test**, when the setting goes off.
  "Off means Monoleaf makes no network request of its own at all" is a promise in
  the toggle's own tooltip, and the cheapest way to keep it is to have nothing
  running. The tick re-reads consent anyway, since it can be switched off from
  another window.
- **Stands down during a download or install.** A check landing mid-download
  would replace the `PendingUpdate` the download is about to attach bytes to.
- **Stamped before the request, not after.** A check that hangs to the 20s
  manifest timeout has still been made; stamping on the way out would let every
  failed check re-arm the next tick to fire immediately.
- **The toggle is renamed.** "Check for updates at startup" is no longer what it
  does. "Automatic update checks" keeps it distinct from the "Check for updates"
  action beside it — the distinction ee706b7 drew deliberately.

## Checklist

- [ ] `npm test` passes
- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] For Rust changes: n/a — no Rust changed
- [x] The byte-for-byte round-trip guarantee still holds (no lossy load/save)
- [x] New in-file constructs degrade gracefully in a plain-Markdown viewer — n/a,
      nothing here touches the `.md`

> **The unchecked boxes mean "not verifiable on the machine I wrote this on",
> not "verified".** It has no Node and no Rust toolchain, so `npm`, `npx` and
> `cargo` don't exist there. `build.yml` runs the full gate on every PR, so CI is
> the check — please don't read the unchecked boxes as a claim that they pass.

## Notes for reviewers

- **This is the one of the four I'd most expect you to push back on**, and the
  issue says so: "Local and private. No network calls for document content, no
  telemetry" is a stated principle, and a background timer is exactly the kind of
  thing that principle exists to keep an eye on. It is gated behind explicit
  consent, it makes one HTTPS request for a small JSON file per day, and it stops
  dead when the toggle goes off — but if a day is the wrong number, or if you'd
  rather the answer stay "startup only" and the toggle keep its old label, this
  is the PR to close rather than the one to negotiate down.
- **Conflicts with #7 and #8.** All three create `src/updates.ts` and
  `src/updates.test.ts` and touch the same region of `src/main.ts`. The functions
  and tests are disjoint, so resolution is concatenation, but whichever merges
  second needs a rebase.
- **A known gap, deliberately not fixed here.** The timer lives in the main
  window, so if the main window is closed while document windows stay open, the
  periodic check stops. That's the same main-window assumption `startupUpdateFlow`
  already makes, and #3 is where it gets resolved properly — fixing it here would
  mean building the multi-window plumbing twice.
- **Suspend/resume is reasoned about, not observed.** I can't build or run the
  app on this machine. The wall-clock comparison is what makes the reasoning hold
  regardless of how WebView2 treats timers across sleep — that's precisely why
  it's written this way rather than as a long `setInterval` — but if you can
  exercise a real suspend before merging, that's the check I'd want.
