### PR TITLE
fix(updater): show the offer to the user, not to one window

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -586,6 +586,26 @@ async fn check_for_update(
     }
 }
 
+/// What is currently on offer, for a window that was not open when the check
+/// happened.
+///
+/// Read-only, and deliberately so: it contacts nothing and decides nothing, it
+/// reports the state `check_for_update` already put there. That is what makes it
+/// safe to call from every window at startup — a window opening cannot cause a
+/// network request, which is the property the consent switch is protecting.
+///
+/// `None` in a debug build, because `check_for_update` never populates the state
+/// there. No `cfg` needed to arrange that; it falls out.
+#[tauri::command]
+fn get_pending_update(app: AppHandle) -> Option<UpdateInfo> {
+    let state = app.state::<PendingUpdate>();
+    let guard = state.0.lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref().map(|pending| UpdateInfo {
+        version: pending.update.version.clone(),
+        notes: pending.update.body.clone(),
+    })
+}
+
 /// Download the update found by `check_for_update`, reporting progress.
 #[tauri::command]
 async fn download_update(
@@ -950,6 +970,7 @@ pub fn run() {
             open_document_window,
             take_window_payload,
             check_for_update,
+            get_pending_update,
             download_update,
             install_update,
             discard_pending_update,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { EditorView, keymap } from "@codemirror/view";
 import { editorSetup, rawViewExtensions } from "./setup";
 import { Compartment, Prec, StateCommand } from "@codemirror/state";
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -2140,6 +2140,29 @@ function askUpdateConsent(): Promise<"yes" | "no"> {
   });
 }
 
+/**
+ * How windows tell each other what the user has been offered and what they have
+ * done about it.
+ *
+ * The offer is app-global — Rust holds one `PendingUpdate` for the process — but
+ * the bar showing it was per-window, and only the main window ever checked. In a
+ * session with a document window open, which is the ordinary way this app gets
+ * used, the offer appeared in a window the user might not be looking at and the
+ * one they *were* in showed nothing.
+ *
+ * Every payload carries the label of the window that sent it, and every listener
+ * ignores its own: `emit` delivers to all webviews including the sender, so
+ * without that the deciding window would immediately re-render from its own
+ * broadcast.
+ */
+const UPDATE_OFFER_EVENT = "update-offer";
+const UPDATE_CLEARED_EVENT = "update-cleared";
+
+interface UpdateBroadcast {
+  source: string;
+  info: UpdateInfo;
+}
+
 function hideUpdateBar() {
   updateBar.hidden = true;
   updateProgress.hidden = true;
@@ -2147,6 +2170,12 @@ function hideUpdateBar() {
   updateReadyToInstall = false;
 }
 
+/**
+ * Put an offer on screen in THIS window. Display only — see
+ * `announceUpdateOffer` for the one that tells the other windows, and note that
+ * the listener below deliberately calls this one, which is what stops a
+ * broadcast from echoing.
+ */
 function showUpdateOffer(info: UpdateInfo) {
   offeredUpdate = info;
   updateReadyToInstall = false;
@@ -2156,6 +2185,75 @@ function showUpdateOffer(info: UpdateInfo) {
   updateAction.disabled = false;
   updateAction.hidden = false;
   updateBar.hidden = false;
+}
+
+/**
+ * Show an offer here and in every other window.
+ *
+ * Called only from the paths that have *decided* to offer, never from the
+ * listener. Keeping the decision on this side rather than broadcasting from Rust
+ * is what lets a policy that lives in the frontend — consent, and anything later
+ * that suppresses an offer — apply once, in the window that made the call,
+ * instead of having to be re-implemented in every listener.
+ */
+function announceUpdateOffer(info: UpdateInfo) {
+  showUpdateOffer(info);
+  const payload: UpdateBroadcast = { source: windowLabel, info };
+  // A failure here costs the other windows their banner and nothing else, so it
+  // must not take down the offer in the window that actually found it.
+  void emit(UPDATE_OFFER_EVENT, payload).catch(() => {});
+}
+
+/**
+ * Take the offer down here and in every other window.
+ *
+ * Dismiss means "not now" for the app, not for one window: the alternative is a
+ * bar the user has already dealt with waiting for them behind every other
+ * document they had open.
+ */
+function announceUpdateCleared() {
+  hideUpdateBar();
+  void emit(UPDATE_CLEARED_EVENT, { source: windowLabel }).catch(() => {});
+}
+
+/**
+ * Listen for what the other windows have decided.
+ *
+ * Runs in every window, including the main one — the main window is not
+ * privileged here, it is just the one that happens to run the startup check.
+ */
+function setupUpdateSync() {
+  void listen<UpdateBroadcast>(UPDATE_OFFER_EVENT, (event) => {
+    if (event.payload.source === windowLabel) return;
+    // Not while this window is mid-download or mid-install: its bar is showing
+    // progress that another window's offer would overwrite, and the offer is for
+    // the same update it is already busy installing.
+    if (updateBusy || updateReadyToInstall) return;
+    showUpdateOffer(event.payload.info);
+  }).catch(() => {});
+
+  void listen<{ source: string }>(UPDATE_CLEARED_EVENT, (event) => {
+    if (event.payload.source === windowLabel) return;
+    if (updateBusy || updateReadyToInstall) return;
+    hideUpdateBar();
+  }).catch(() => {});
+}
+
+/**
+ * Adopt an offer that was made before this window existed.
+ *
+ * The broadcast above only reaches windows that are already open, so a document
+ * window opened by double-clicking a `.md` an hour into the session would
+ * otherwise be the one window with no idea. This asks Rust what is already on
+ * offer; it contacts nothing, so a window opening can never cause a network
+ * request.
+ */
+async function adoptPendingUpdate() {
+  if (updateConsent() !== "yes") return;
+  const info = await invoke<UpdateInfo | null>("get_pending_update").catch(
+    () => null,
+  );
+  if (info !== null) showUpdateOffer(info);
 }
 
 /**
@@ -2169,7 +2267,7 @@ async function checkForUpdate(userInitiated: boolean) {
     const info = await invoke<UpdateInfo | null>("check_for_update", {
       userInitiated,
     });
-    if (info !== null) showUpdateOffer(info);
+    if (info !== null) announceUpdateOffer(info);
     else if (userInitiated) {
       await uiAlert(`Monoleaf ${await getVersion()} is the latest version.`, {
         title: "No update available",
@@ -2275,7 +2373,7 @@ updateAction.addEventListener("click", () => {
 });
 document
   .getElementById("btn-dismiss-update")!
-  .addEventListener("click", hideUpdateBar);
+  .addEventListener("click", announceUpdateCleared);
 
 /**
  * The settings toggle. Renders off while consent is unset, because nothing is
@@ -2292,8 +2390,10 @@ function toggleUpdateChecks() {
     void checkForUpdate(true);
   } else {
     // Rust has to forget any downloaded update too, or install-on-click stays
-    // armed for a feature the user has just switched off.
-    hideUpdateBar();
+    // armed for a feature the user has just switched off. Broadcast, because a
+    // bar left standing in another window would still be able to install the
+    // thing this switch just turned off.
+    announceUpdateCleared();
     void invoke("discard_pending_update").catch(() => {});
   }
   view.focus();
@@ -2309,7 +2409,13 @@ function toggleUpdateChecks() {
  * one call site.
  */
 async function startupUpdateFlow() {
-  if (!isMainWindow) return; // one consent question per install, not per window
+  if (!isMainWindow) {
+    // Still no consent question and still no check — those stay the main
+    // window's job, one per install. What this window does need is whatever is
+    // already on offer, which costs no network and no dialog.
+    await adoptPendingUpdate();
+    return;
+  }
   if (updateConsent() === "unset") {
     const answer = await askUpdateConsent();
     localStorage.setItem(UPDATE_CONSENT_KEY, answer);
@@ -3126,6 +3232,9 @@ window.addEventListener(
 // window is in that state. The registration is an IPC round trip, so the gap
 // cannot be closed entirely — only kept as short as possible.
 setupRecoveryFlush();
+// Before the startup chain, so a check that finishes quickly in the main window
+// cannot broadcast its offer into a window that is not listening yet.
+setupUpdateSync();
 setupWindowControls();
 setupCloseGuard();
 applyViewClass();


### PR DESCRIPTION
## What & why

Closes #3.

The pending update is app-global — Rust holds one `PendingUpdate` for the process
— but the bar showing it was per-window state (`offeredUpdate`) and only the main
window ever checked (`startupUpdateFlow`). In a session with a document window
open, which is the ordinary way this app gets used, the offer appeared in a
window the user might not be looking at and the one they *were* in showed
nothing. Dismissing in one window left it standing in the others.

To be clear about what already worked and is unchanged: **the manual "Check for
updates" has always worked in every window** (`btn-check-now`) and is still
deliberately independent of the consent toggle. This is about the *automatic*
offer.

## Two paths, because there are two orderings

1. **A window already open learns by broadcast.** The window that decides to
   offer emits; every other window renders.
2. **A window opened afterwards asks.** New read-only `get_pending_update`
   command. It contacts nothing and decides nothing — it reports state that
   `check_for_update` already put there — so a window opening still cannot cause
   a network request, which is the property the consent switch is protecting.

## The choice worth your attention: the broadcast comes from the frontend, not Rust

The issue proposed Rust emitting when it finds an update. Writing it, that turned
out to be wrong, and it's the one thing here I'd most want checked.

The decision to offer belongs with the policy that governs it, and that policy
lives in the frontend: consent is in `localStorage`, and anything added later
that suppresses an offer will be too. Emitting from Rust puts the decision on the
far side of the policy — Rust would announce an offer that the deciding window
had already decided *not* to show, and every listener would have to re-implement
the suppression to compensate. (Concretely: #8's skipped-version check is a
frontend decision in `checkForUpdate`. With a Rust-side broadcast, a skipped
version would be suppressed in the checking window and shown in all the others.)

So `showUpdateOffer` renders and `announceUpdateOffer` renders-and-tells;
listeners call the first, which is what stops a broadcast echoing.

## Other details

- Every payload carries the sending window's label and every listener ignores its
  own — `emit` delivers to all webviews **including the sender**.
- Listeners stand down while their own window is mid-download or mid-install,
  where another window's offer would overwrite a progress bar for the very update
  that window is already installing.
- `setupUpdateSync()` runs before the startup chain, so a fast check in the main
  window can't broadcast into a window that isn't listening yet.
- Switching the toggle off now broadcasts too: a bar left standing elsewhere
  could otherwise still install the thing the switch just turned off.
- **No new capability.** `emit`/`listen` are already granted via `core:default`;
  `capabilities/default.json` is untouched, and the frontend still has no updater
  plugin permissions.
- Consent stays a main-window question, asked once per install. This changes who
  sees the answer, not who is asked.

## Checklist

- [ ] `npm test` passes
- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run lint` and `npm run format:check` pass
- [ ] `cargo test` / `cargo clippy` / `cargo fmt --check` pass
- [x] The byte-for-byte round-trip guarantee still holds (no lossy load/save)
- [x] New in-file constructs degrade gracefully in a plain-Markdown viewer — n/a,
      nothing here touches the `.md`

> **The unchecked boxes mean "not verifiable on the machine I wrote this on",
> not "verified".** It has no Node and no Rust toolchain, so `npm`, `npx` and
> `cargo` don't exist there. **This is the one of the four with a Rust change**,
> so it's the one where that matters most — `get_pending_update` has not been
> compiled by me. It follows the lock-bind-then-map shape of `download_update`
> immediately above it precisely because I couldn't check a more compact form
> borrow-checks. `build.yml` runs the full gate on every PR; please treat CI as
> the first real verification.

## Notes for reviewers

- **No new Rust test.** The existing `mod tests` in `lib.rs` covers pure
  functions; `get_pending_update` needs an `AppHandle` and a populated
  `PendingUpdate`, which is a harness this file doesn't have. I didn't want to
  introduce one as a side effect of a small command. Say if you'd rather it were
  there and I'll add it.
- **Conflicts with #7, #8 and #9.** All four touch `src/main.ts:2058-2320`; the
  other three also create `src/updates.ts`. This one doesn't, so it's the least
  entangled of the set on that particular file.
- **Interaction with #8 worth sequencing.** If both land, `announceUpdateOffer`
  is the right place for #8's skipped-version check to sit — it's already the
  single "we have decided to offer" chokepoint. Merging #8 first and rebasing
  this on top makes that fall out naturally; the other order needs a deliberate
  look at where the skip test ends up.
- **Not tested against a real multi-window session.** I can't build or run the
  app here. The two orderings this is meant to fix — offer-then-open-window, and
  window-open-then-offer — are exactly what I'd exercise before merging.
