### PR TITLE
fix(updater): make the flush wait visibly a wait, not a silent install

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -774,7 +774,7 @@ fn flush_recovery_snapshots(app: &AppHandle) -> Result<(), String> {
             })
             .collect();
         return Err(format!(
-            "Update postponed: {} did not confirm saving its unsaved work.",
+            "Update postponed: {} hasn't confirmed saving its unsaved work yet.",
             named.join(", ")
         ));
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2400,7 +2400,14 @@ async function installOfferedUpdate() {
 
   updateBusy = true;
   updateAction.disabled = true;
-  updateText.textContent = "Installing…";
+  // Named for the phase that is actually visible: install_update spends its
+  // observable time waiting on every window's flush acknowledgement (up to
+  // FLUSH_ACK_TIMEOUT), and the native install + relaunch after that is
+  // effectively instantaneous — the process is gone before this could update
+  // again. "Installing…" during the wait misread as progress, making the
+  // eventual postponement read as an unexplained failure rather than a wait
+  // that ran out.
+  updateText.textContent = "Saving unsaved windows…";
   try {
     await invoke("install_update");
     // Not reached on success: the installer takes over and the process exits.


### PR DESCRIPTION
## Summary
- `installOfferedUpdate` set the button text to "Installing…" immediately on click, but the observable time in `install_update` is almost entirely spent waiting on every window's flush acknowledgement (up to `FLUSH_ACK_TIMEOUT` = 3s) — the actual native install + relaunch after that is effectively instant, since the process exits. "Installing…" during that wait read as progress, so a postponement landed as an unexplained failure rather than a wait that ran out. Changed the text to "Saving unsaved windows…", which names the phase that's actually happening.
- Softened the Rust postponement message from "did not confirm saving its unsaved work" (reads as an accusation/failure) to "hasn't confirmed saving its unsaved work yet" (states the same fact — the window hasn't acked — without implying it refused or failed).

Fixes #23

## Test plan
- [x] `tsc --noEmit`, `npm run build`, `npm run test` (477/477), `npm run lint`
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (all pass)