### PR TITLE
fix(editor): make Tab insert/indent in the document instead of moving focus

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,4 +1,10 @@
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentLess,
+  insertTab,
+} from "@codemirror/commands";
 import {
   bracketMatching,
   defaultHighlightStyle,
@@ -51,6 +57,15 @@ export const editorSetup: Extension = [
     ...searchKeymap,
     ...historyKeymap,
     ...foldKeymap,
+    // defaultKeymap has no Tab binding at all (CodeMirror leaves it free for
+    // browser focus navigation by default), which is why Tab was landing on
+    // the toolbar instead of the document. insertTab puts a tab character at
+    // the cursor, or indents every selected line when there's a selection —
+    // the same split codemirror.net's own examples use, and it matches what a
+    // Word-like editor's users expect from the key. This doesn't trap
+    // keyboard focus: CodeMirror's core view already treats Escape as "let
+    // the next Tab through to the browser" independent of this keymap.
+    { key: "Tab", run: insertTab, shift: indentLess },
   ]),
 ];
 


### PR DESCRIPTION
## Summary
- `defaultKeymap` (from `@codemirror/commands`) has no binding for Tab at all — CodeMirror leaves it free by design so the browser's native focus navigation can use it. That meant pressing Tab while editing moved keyboard focus to the next focusable element (e.g. a toolbar/zoom button) instead of doing anything to the document.
- Added an explicit `{ key: "Tab", run: insertTab, shift: indentLess }` binding to `editorSetup`'s keymap. `insertTab` inserts a literal tab character at the cursor, or indents every selected line when there's a selection — the same split CodeMirror's own examples use, and matches what a Word-like editor's users expect from the key. Shift-Tab dedents.
- This doesn't trap keyboard-only users: CodeMirror's core view already implements "Escape lets the next Tab through to the browser" independent of any keymap, so the usual escape hatch still works.

## Test plan
- [x] `tsc --noEmit`, `npm run build`, `npm run test` (477/477), `npm run lint`
- [x] Manually verified with a real `EditorView` (jsdom): dispatching a `Tab` keydown now inserts `\t` at the cursor and the event is marked handled (default browser action suppressed); dispatching `Tab` over a multi-line selection indents each line instead