### PR TITLE
ci(release): ship the Linux AppImage alongside the Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,17 @@
 #
 #     git tag v1.0.0 && git push origin v1.0.0
 #
-# It runs the tests, builds the Windows installer, and creates a DRAFT GitHub
-# Release with the installer attached — you review and click "Publish" so
-# nothing goes public by accident. (Can also be run manually from the Actions
-# tab via workflow_dispatch, from a tagged commit.)
+# It runs the tests, builds the Windows installer and the Linux AppImage, and
+# creates a DRAFT GitHub Release with both attached — you review and click
+# "Publish" so nothing goes public by accident. (Can also be run manually from
+# the Actions tab via workflow_dispatch, from a tagged commit.)
 #
-# Windows-only for now: it is the tested, primary target. macOS/Linux are built
-# for verification by build.yml but not shipped until they can be tested/signed.
+# Windows is the tested, primary target. Linux ships too, labeled best-effort in
+# the release body below — it is community-tested (works on at least one real
+# machine outside CI), not exercised as broadly as Windows. macOS stays
+# verification-only in build.yml: unlike the other two, an unsigned/unnotarized
+# .dmg is a hard Gatekeeper block for most users rather than a click-through
+# warning, so shipping it needs a paid Apple Developer account first.
 name: release
 
 on:
@@ -127,7 +131,19 @@ jobs:
   release:
     if: ${{ !inputs.updater_dry_run }}
     needs: [version, gate]
-    runs-on: windows-latest
+    # Two platforms, one release: both legs target the same tagName, and
+    # tauri-action's own find-or-create-by-tag logic (not a separate
+    # create-release job) is what upstream's own multi-platform example relies
+    # on, so this follows that rather than inventing a second pattern.
+    # fail-fast: false, matching build.yml — a Linux bundle failure must not
+    # cancel the Windows upload that was already in flight, and the draft
+    # state is what makes an incomplete pair of assets safe to notice and fix
+    # before publishing rather than something that ships silently.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, ubuntu-24.04]
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: write # create the GitHub Release and upload the installer
     steps:
@@ -141,6 +157,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch @ 2026-07-16
         with:
           toolchain: stable # the SHA pin hides which toolchain this is
+
+      - uses: ./.github/actions/linux-deps
+        if: startsWith(matrix.platform, 'ubuntu')
 
       - run: npm ci
 
@@ -168,7 +187,11 @@ jobs:
           args: --config ${{ github.workspace }}/src-tauri/tauri.release.conf.json5
           tagName: ${{ github.ref_name }}
           releaseName: "Monoleaf ${{ github.ref_name }}"
-          releaseBody: "See the assets below to download and install. The installer is unsigned (SmartScreen may warn: More info → Run anyway)."
+          releaseBody: >-
+            See the assets below to download and install. The Windows installer
+            is unsigned (SmartScreen may warn: More info → Run anyway). The
+            Linux AppImage is community-tested, best-effort — please file an
+            issue if you hit a problem with it.
           # Draft is unconditional: it is the safety property, so nothing gets
           # to make it depend on the tag.
           releaseDraft: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ What you write stays plain Markdown that any editor, GitHub, or an LLM can read.
 
 [![version](https://img.shields.io/github/v/release/vibingbiochemist/Monoleaf?label=version&color=E8A33D)](https://github.com/vibingbiochemist/Monoleaf/releases)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![platform](https://img.shields.io/badge/platform-Windows-0078D6)](https://github.com/vibingbiochemist/Monoleaf/releases)
+[![platform](https://img.shields.io/badge/platform-Windows_%26_Linux-0078D6)](https://github.com/vibingbiochemist/Monoleaf/releases)
 [![built with Tauri](https://img.shields.io/badge/built%20with-Tauri%20%2B%20CodeMirror-24C8DB)](https://tauri.app)
 
 [**monoleaf.org**](https://monoleaf.org) · [Download](https://github.com/vibingbiochemist/Monoleaf/releases) · [Report an issue](https://github.com/vibingbiochemist/Monoleaf/issues)
@@ -119,10 +119,14 @@ writing docs, anyone who wants their work to still open cleanly in ten years.
   references, which tells whoever wrote it when and from where you opened it.
   A blocked image shows as its alt text instead
 
-## Download & install (Windows)
+## Download & install
 
-Grab the latest installer from the
-[**Releases**](https://github.com/vibingbiochemist/Monoleaf/releases) page and run it.
+Grab the latest release from the
+[**Releases**](https://github.com/vibingbiochemist/Monoleaf/releases) page.
+
+### Windows
+
+Run the installer.
 
 - Installs **per-user**, with **no administrator rights** required.
 - If your machine lacks the Microsoft **WebView2** runtime, the installer
@@ -133,6 +137,21 @@ Grab the latest installer from the
 > paying a commercial certificate authority every year, which is hard to justify for
 > a free tool with one maintainer, so it is **not planned** rather than pending. If
 > you would rather not run an unsigned binary, build it yourself: see below.
+
+### Linux
+
+Download the `.AppImage`, make it executable, and run it:
+
+```bash
+chmod +x Monoleaf_*.AppImage
+./Monoleaf_*.AppImage
+```
+
+> **Note:** the Linux build is **community-tested, best-effort** — it isn't
+> exercised as broadly as Windows, so please
+> [file an issue](https://github.com/vibingbiochemist/Monoleaf/issues) if you
+> hit a problem with it. Unlike Windows, there is no OS-level signing prompt to
+> click through: AppImage runs directly, with no publisher warning.
 
 ## Build from source
 
@@ -146,22 +165,25 @@ npm run tauri build    # build the installer → src-tauri/target/release/bundle
 
 ### Platform support
 
-**Windows is the tested and distributed target.** Monoleaf is a Tauri app, so the
-same source builds on macOS and Linux, and `npm run tauri build` produces a
-`.dmg` or `.AppImage`. But be aware of what that does and does not mean:
+**Windows and Linux are distributed; Windows is the more thoroughly tested of
+the two.** Monoleaf is a Tauri app, so the same source also builds on macOS,
+and `npm run tauri build` produces a `.dmg` there. Where each platform stands:
 
-- They **do compile**: CI builds all three platforms on every push, so a break
-  would be caught. What is missing is human testing. Nobody has run the `.dmg` or
-  the `.AppImage` and checked that the editor behaves, so treat them as untested
-  rather than broken.
-- They are **not distributed**. Only the Windows installer is published, and the
-  macOS and Linux bundles would be unsigned too.
+- **Windows**: primary target, most exercised.
+- **Linux**: shipped as an AppImage, but community-tested rather than
+  exercised as broadly as Windows — see the note in the download section
+  above.
+- **macOS**: **not distributed**. CI builds the `.dmg` on every push, so a
+  compile break would be caught, but nobody has run it and checked that the
+  editor behaves, and an unsigned/unnotarized `.dmg` hits Gatekeeper hard
+  enough (not a simple click-through, unlike Windows or Linux) that shipping
+  it well needs a paid Apple Developer account first.
 - Everything the editor does is portable in principle. Native spell-checking is
   the one Windows-specific feature, and it is compiled out elsewhere rather than
   breaking the build.
 
-If you build on macOS or Linux, reports either way are welcome: that is the
-fastest route to making them supported rather than incidental.
+If you build on macOS, or hit anything on Linux, reports either way are
+welcome — that is the fastest route to making both fully supported.
 
 ## Keyboard shortcuts
 


### PR DESCRIPTION
## Summary
- `release.yml`'s `release` job was hardcoded to `windows-latest`, so only the Windows installer ever reached a real GitHub Release — macOS/Linux were built by `build.yml` for CI verification only, never shipped.
- Linux doesn't actually need what was blocking it: AppImage has no OS-level gatekeeping (no Authenticode, no Gatekeeper-style block) — it's `chmod +x` and run, same distribution model as most non-repo-packaged Linux desktop software. The Windows installer is already shipped unsigned today with the same "click through the warning" caveat, so this isn't introducing a new class of risk.
- Turned `release` into a `[windows-latest, ubuntu-24.04]` matrix (`fail-fast: false`, matching `build.yml`'s existing rationale), added the `linux-deps` step Linux needs to compile (already proven in `build.yml`), and both legs upload to the same draft release via `tauri-action`'s own find-or-create-by-tag logic — the same pattern used in tauri-action's own official multi-platform example, not a new one.
- macOS stays verification-only: an unsigned/unnotarized `.dmg` is a hard Gatekeeper block for most users, not a click-through warning, so it needs a paid Apple Developer account before it's worth shipping.
- Updated the release body and `README.md` to be explicit that the Linux build is community-tested/best-effort — it's proven to build and been run successfully on at least one real machine, but hasn't had the exercise Windows has.

## Test plan
- [x] Validated the workflow YAML parses correctly and the `release` job structure matches intent (`js-yaml`)
- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format:check`, `npm test` (477/477) — no source changes, confirming nothing else broke
- [ ] Not yet exercised end-to-end (would require a real tag push or a manual `workflow_dispatch` against an existing tag) — flagging for review before merge since this touches the release/publish pipeline