### PR TITLE
ci: pin Linux installer builds to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,10 @@ jobs:
           fail-on-severity: high
 
   # Installers: windows-latest is NSIS (per-user, no admin), macos-latest is the
-  # .dmg (unsigned for now, see the note at the top), ubuntu-24.04 is the
-  # .AppImage (runs without admin rights).
+  # .dmg (unsigned for now, see the note at the top), ubuntu-22.04 is the
+  # .AppImage (runs without admin rights). Pinned below 24.04 deliberately: glibc
+  # is forward-compatible only, so the build host's glibc becomes the artifact's
+  # minimum. 22.04 is the oldest GA runner and still has WebKitGTK 4.1.
   #
   # A pull request builds only Windows, the one platform that is actually
   # distributed. On a private repository GitHub bills macOS minutes at 10x and
@@ -73,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ github.event_name == 'pull_request' && fromJSON('["windows-latest"]') || fromJSON('["windows-latest","macos-latest","ubuntu-24.04"]') }}
+        platform: ${{ github.event_name == 'pull_request' && fromJSON('["windows-latest"]') || fromJSON('["windows-latest","macos-latest","ubuntu-22.04"]') }}
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, ubuntu-24.04]
+        platform: [windows-latest, ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write # create the GitHub Release and upload the installer


### PR DESCRIPTION
## Summary
- Fixes #27. `release.yml`'s Linux leg and `build.yml`'s Linux matrix entry both built on `ubuntu-24.04`, which ships glibc 2.39. glibc is forward-compatible only, so the AppImage refused to start on Ubuntu 22.04, Debian 12, and RHEL 9 (`GLIBC_2.39' not found`).
- Pinned both to `ubuntu-22.04` (glibc 2.35) instead — the oldest GA runner that still has `libwebkit2gtk-4.1-dev` available (via jammy-updates), so the Tauri build step is unaffected.
- `build.yml` changed too, so CI keeps testing the same base the release actually ships from.

## Note on runner lifecycle
`ubuntu-22.04` runner images begin deprecation 2026-09-17 and are fully unsupported by 2027-04-17 (actions/runner-images#14254), so this fix has a shelf life — worth a follow-up before then, likely building inside a pinned container instead of relying on the runner OS.

## Test plan
- [x] YAML for both workflow files parses (`js-yaml`)
- [x] Confirmed `libwebkit2gtk-4.1-dev` is available on Ubuntu 22.04 (jammy-updates)
- [ ] Not yet exercised end-to-end via a real build — flagging for review since this touches the release path