### PR TITLE
fix(paste): convert Word fake lists to real markdown, fix markdown-source false positive

### DIFF
--- a/src/paste.test.ts
+++ b/src/paste.test.ts
@@ -400,5 +400,47 @@ href="https://www.nobelprize.org/prizes/physics/1921/einstein/biographical/">nob
       expect(md).toContain("| --- | --- |");
       expect(md).toContain("| 1879 | Born in Ulm, Germany |");
     });
+
+    it("converts a list item that also carries paragraph alignment", () => {
+      // Word applies alignment independently of list membership; a justified
+      // or centered list item must still become a real list item, not get
+      // caught by the alignment rule and wrapped in a <div align> block.
+      const justified = `
+        <p class=MsoListParagraph style='text-align:justify;margin-left:.5in;text-indent:-.25in;mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>&#8226;<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>First item<o:p></o:p></p>
+        <p class=MsoListParagraph style='text-align:justify;margin-left:.5in;text-indent:-.25in;mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>&#8226;<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Second item<o:p></o:p></p>`;
+      expect(htmlToMarkdown(justified)).toBe("- First item\n- Second item");
+      // A genuinely non-list justified paragraph is unaffected.
+      expect(
+        htmlToMarkdown('<p style="text-align:justify">Just a paragraph.</p>'),
+      ).toBe('<div align="justify">\n\nJust a paragraph.\n\n</div>');
+    });
+
+    it("converts Word's CxSpFirst/CxSpMiddle/CxSpLast continuation classes", () => {
+      // Word glues these directly onto the class name (no separator) for
+      // consecutive list paragraphs it treats as "connected" — a paragraph-
+      // spacing optimization unrelated to list structure.
+      const cxsp = `
+        <p class=MsoListParagraphCxSpFirst style='margin-left:.5in;text-indent:-.25in;mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>&#8226;<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>First item<o:p></o:p></p>
+        <p class=MsoListParagraphCxSpMiddle style='margin-left:.5in;text-indent:-.25in;mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>&#8226;<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Second item<o:p></o:p></p>
+        <p class=MsoListParagraphCxSpLast style='margin-left:.5in;text-indent:-.25in;mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>&#8226;<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Third item<o:p></o:p></p>`;
+      expect(htmlToMarkdown(cxsp)).toBe(
+        "- First item\n- Second item\n- Third item",
+      );
+    });
+
+    it("KNOWN LIMITATION: a nested sub-item resets the parent level's ordinal", () => {
+      // Documented at msoListSibling: adjacency requires an exact level
+      // match, so a level-2 item between two level-1 items breaks the
+      // level-1 run — the second "1." should read "2.". Pinned here so a
+      // future fix (or regression) shows up as an intentional test change,
+      // not a silent behavior drift.
+      const nested = `
+        <p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;mso-list:l0 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>1.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Top item one<o:p></o:p></p>
+        <p class=MsoListParagraph style='margin-left:1in;text-indent:-.25in;mso-list:l0 level2 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>a.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Sub item<o:p></o:p></p>
+        <p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;mso-list:l0 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>2.<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></span><![endif]>Top item two<o:p></o:p></p>`;
+      expect(htmlToMarkdown(nested)).toBe(
+        "1. Top item one\n\n  1. Sub item\n\n1. Top item two",
+      );
+    });
   });
 });

--- a/src/paste.test.ts
+++ b/src/paste.test.ts
@@ -37,6 +37,17 @@ describe("looksLikeMarkdown (paste raw markdown verbatim)", () => {
       true,
     );
   });
+
+  it("does not mistake Word's tab-separated plain-text list markers for markdown", () => {
+    // Word's plain-text clipboard flavor writes list items as "•\titem" /
+    // "1.\titem" — a literal tab, which a human typing markdown never uses.
+    // Misfiring here means the (genuinely rich) HTML flavor never gets
+    // converted at all.
+    expect(looksLikeMarkdown("1.\t1915: General relativity")).toBe(false);
+    expect(looksLikeMarkdown("•\tThe photoelectric effect")).toBe(false);
+    // A real space still counts.
+    expect(looksLikeMarkdown("1. General relativity")).toBe(true);
+  });
 });
 
 describe("htmlHasRichFormatting (markdown-source vs rich paste)", () => {
@@ -215,5 +226,179 @@ describe("htmlToMarkdown (paste with formatting)", () => {
   it("collapses blank-line pileups", () => {
     const md = htmlToMarkdown("<div><div><p>a</p></div></div><p>b</p>");
     expect(md).toBe("a\n\nb");
+  });
+
+  // Captured verbatim from a real Word 15 clipboard paste (via the
+  // monoleaf-paste-debug.html dump), trimmed of the ~700 lines of unrelated
+  // <w:LsdException> style-registry noise. Keeps both conditional-comment
+  // forms Word emits: the downlevel-hidden <!--[if gte mso 9]>...<![endif]-->
+  // wrapping the XML payload, and the downlevel-revealed <![if
+  // !supportLists]>...<![endif]> (no <!--/--> wrapper) wrapping each fake
+  // list item's throwaway marker span.
+  const WORD_PASTE_HTML = `<html xmlns:o="urn:schemas-microsoft-com:office:office"
+xmlns:w="urn:schemas-microsoft-com:office:word"
+xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Word.Document>
+<!--[if gte mso 9]><xml>
+ <w:WordDocument>
+  <w:View>Normal</w:View>
+  <w:Zoom>0</w:Zoom>
+ </w:WordDocument>
+</xml><![endif]-->
+<style>
+<!--
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	font-size:10.0pt;
+	font-family:"Times New Roman",serif;}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+	{margin:0in;
+	font-size:10.0pt;
+	font-family:"Times New Roman",serif;}
+-->
+</style>
+</head>
+<body lang=EN-US style='tab-interval:.5in;word-wrap:break-word'>
+<!--StartFragment-->
+
+<h1>Albert Einstein<o:p></o:p></h1>
+
+<p class=MsoNormal>Albert Einstein (1879–1955) was a <b>German-born theoretical
+physicist</b> widely regarded as one of the most influential scientists of the
+twentieth century. He is best known for developing the <i>theory of relativity</i>,
+one of the two pillars of modern physics alongside quantum mechanics.<o:p></o:p></p>
+
+<h2>The Annus Mirabilis papers<o:p></o:p></h2>
+
+<p class=MsoNormal>In 1905, often called his &quot;miracle year,&quot; Einstein
+published four papers that transformed physics:<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><![endif]>The photoelectric effect, explaining light as discrete
+quanta of energy<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><![endif]>Brownian motion, providing strong evidence for the
+existence of atoms<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><![endif]>Special relativity, redefining space and time for
+objects in relative motion<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l1 level1 lfo1'><![if !supportLists]><span style='mso-list:Ignore'>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><![endif]>Mass–energy equivalence, expressed in the equation E =
+mc²<o:p></o:p></p>
+
+<h2>Later career<o:p></o:p></h2>
+
+<p class=MsoNormal>Key milestones after 1905 include:<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l0 level1 lfo2'><![if !supportLists]><span style='mso-list:Ignore'>1.<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><![endif]>1915:
+Publication of the general theory of relativity<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l0 level1 lfo2'><![if !supportLists]><span style='mso-list:Ignore'>2.<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><![endif]>1919:
+Solar eclipse observations by Eddington confirm light bending predicted by
+general relativity<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l0 level1 lfo2'><![if !supportLists]><span style='mso-list:Ignore'>3.<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><![endif]>1921:
+Awarded the Nobel Prize in Physics for the photoelectric effect<o:p></o:p></p>
+
+<p class=MsoListParagraph style='margin-left:.5in;text-indent:-.25in;
+mso-list:l0 level1 lfo2'><![if !supportLists]><span style='mso-list:Ignore'>4.<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><![endif]>1933:
+Emigrates to the United States, joining the Institute for Advanced Study in
+Princeton<o:p></o:p></p>
+
+<h2>Further reading<o:p></o:p></h2>
+
+<p class=MsoNormal>Nobel Prize biography: <a
+href="https://www.nobelprize.org/prizes/physics/1921/einstein/biographical/">nobelprize.org/prizes/physics/1921/einstein</a><o:p></o:p></p>
+
+<h2>Key dates at a glance<o:p></o:p></h2>
+
+<table class=MsoNormalTable border=1 cellspacing=0 cellpadding=0 width=632
+ style='width:474.0pt;border-collapse:collapse;border:none'>
+ <tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes'>
+  <td width=160 valign=top style='width:120.0pt;border:solid windowtext 1.0pt;
+  background:#D9E2F3'>
+  <p class=MsoNormal><b><span style='color:black'>Year</span></b><o:p></o:p></p>
+  </td>
+  <td width=472 valign=top style='width:354.0pt;border:solid windowtext 1.0pt;
+  background:#D9E2F3'>
+  <p class=MsoNormal><b><span style='color:black'>Event</span></b><o:p></o:p></p>
+  </td>
+ </tr>
+ <tr style='mso-yfti-irow:1'>
+  <td width=160 valign=top style='border:solid windowtext 1.0pt'>
+  <p class=MsoNormal>1879<o:p></o:p></p>
+  </td>
+  <td width=472 valign=top style='border:solid windowtext 1.0pt'>
+  <p class=MsoNormal>Born in Ulm, Germany<o:p></o:p></p>
+  </td>
+ </tr>
+</table>
+
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
+
+<!--EndFragment-->
+</body>
+
+</html>`;
+
+  describe("Word fake lists (MsoListParagraph)", () => {
+    const md = htmlToMarkdown(WORD_PASTE_HTML);
+
+    it("converts the bullet list to a real GFM unordered list", () => {
+      expect(md).toContain(
+        "- The photoelectric effect, explaining light as discrete quanta of energy\n" +
+          "- Brownian motion, providing strong evidence for the existence of atoms\n" +
+          "- Special relativity, redefining space and time for objects in relative motion\n" +
+          "- Mass–energy equivalence, expressed in the equation E = mc²",
+      );
+    });
+
+    it("converts the numbered list to a real GFM ordered list", () => {
+      expect(md).toContain(
+        "1. 1915: Publication of the general theory of relativity\n" +
+          "2. 1919: Solar eclipse observations by Eddington confirm light bending predicted by general relativity\n" +
+          "3. 1921: Awarded the Nobel Prize in Physics for the photoelectric effect\n" +
+          "4. 1933: Emigrates to the United States, joining the Institute for Advanced Study in Princeton",
+      );
+    });
+
+    it("leaves no MsoListParagraph/marker debris behind", () => {
+      expect(md).not.toContain("MsoListParagraph");
+      expect(md).not.toContain("mso-list");
+      expect(md).not.toContain("supportLists");
+    });
+
+    it("still converts headings, bold/italic, the link, and the table unchanged", () => {
+      expect(md).toContain("# Albert Einstein");
+      expect(md).toContain("## The Annus Mirabilis papers");
+      expect(md).toContain("**German-born theoretical physicist**");
+      expect(md).toContain("*theory of relativity*");
+      expect(md).toContain(
+        "[nobelprize.org/prizes/physics/1921/einstein](https://www.nobelprize.org/prizes/physics/1921/einstein/biographical/)",
+      );
+      expect(md).toContain("| **Year** | **Event** |");
+      expect(md).toContain("| --- | --- |");
+      expect(md).toContain("| 1879 | Born in Ulm, Germany |");
+    });
   });
 });

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -55,48 +55,6 @@ function service(): TurndownService {
     },
   });
 
-  // Word's fake lists: a flat run of <p class=MsoListParagraph> (or the <div>
-  // form), each carrying its list id/level in style="mso-list:l1 level1 ..."
-  // and a throwaway marker glyph in a <span style="mso-list:Ignore"> child —
-  // there is no real <ul>/<ol>/<li> anywhere. This rule regroups consecutive
-  // siblings that share a list id+level into one logical list, numbering
-  // ordered items by position in the run (Word's own marker text is only used
-  // to tell ordered from unordered) and dropping the marker span entirely.
-  td.addRule("msoFakeList", {
-    filter: (node) => msoListInfo(node as Element) !== null,
-    replacement: (_content, node) => {
-      const el = node as HTMLElement;
-      const info = msoListInfo(el)!;
-
-      const clone = el.cloneNode(true) as HTMLElement;
-      const marker = Array.from(clone.querySelectorAll("span")).find((s) =>
-        /mso-list:\s*ignore/i.test(s.getAttribute("style") ?? ""),
-      );
-      const markerText = marker?.textContent?.trim() ?? "";
-      marker?.remove();
-
-      const text = td.turndown(clone.innerHTML).trim();
-      if (text === "") return "";
-
-      const indent = "  ".repeat(info.level - 1);
-      const ordinal = msoListOrdinal(el, info);
-      const prefix = isOrderedMsoMarker(markerText)
-        ? `${ordinal}. `
-        : `${td.options.bulletListMarker} `;
-
-      const isFirst = !msoListSibling(el, info, "previous");
-      const isLast = !msoListSibling(el, info, "next");
-      return (
-        (isFirst ? "\n\n" : "") +
-        indent +
-        prefix +
-        text.replace(/\n/g, `\n${indent}  `) +
-        "\n" +
-        (isLast ? "\n" : "")
-      );
-    },
-  });
-
   // Tables → GFM. turndown-plugin-gfm only converts a table whose first row is
   // a proper heading row (<th> / <thead>); Word emits header cells as bold
   // <td>s with no <thead>, so the plugin `keep`s the whole table as raw HTML.
@@ -168,10 +126,15 @@ function service(): TurndownService {
       (node as HTMLElement).getAttribute("alt") ?? "",
   });
 
-  // Word/HTML paragraph alignment -> our <div align> blocks.
+  // Word/HTML paragraph alignment -> our <div align> blocks. Checked before
+  // msoFakeList below (turndown's Rules.add() unshifts, so the rule added
+  // *last* wins) — this filter only matches non-list paragraphs anyway, since
+  // msoListInfo's own class/style check excludes it, but the ordering keeps
+  // that explicit rather than relying on the exclusion alone.
   td.addRule("alignment", {
     filter: (node) => {
       if (!/^(P|DIV|H[1-6])$/.test(node.nodeName)) return false;
+      if (msoListInfo(node as Element) !== null) return false;
       return alignmentOf(node as HTMLElement) !== null;
     },
     replacement: (content, node) => {
@@ -179,6 +142,52 @@ function service(): TurndownService {
       const inner = content.trim();
       if (inner === "") return "";
       return `\n\n<div align="${align}">\n\n${inner}\n\n</div>\n\n`;
+    },
+  });
+
+  // Word's fake lists: a flat run of <p class=MsoListParagraph> (or the <div>
+  // form), each carrying its list id/level in style="mso-list:l1 level1 ..."
+  // and a throwaway marker glyph in a <span style="mso-list:Ignore"> child —
+  // there is no real <ul>/<ol>/<li> anywhere. This rule regroups consecutive
+  // siblings that share a list id+level into one logical list, numbering
+  // ordered items by position in the run (Word's own marker text is only used
+  // to tell ordered from unordered) and dropping the marker span entirely.
+  // Added last (see the ordering note on "alignment" above) so a justified or
+  // centered list item — Word applies paragraph alignment independently of
+  // list membership — still converts to a real list item instead of being
+  // caught by the alignment rule and wrapped in a <div align> block.
+  td.addRule("msoFakeList", {
+    filter: (node) => msoListInfo(node as Element) !== null,
+    replacement: (_content, node) => {
+      const el = node as HTMLElement;
+      const info = msoListInfo(el)!;
+
+      const clone = el.cloneNode(true) as HTMLElement;
+      const marker = Array.from(clone.querySelectorAll("span")).find((s) =>
+        /mso-list:\s*ignore/i.test(s.getAttribute("style") ?? ""),
+      );
+      const markerText = marker?.textContent?.trim() ?? "";
+      marker?.remove();
+
+      const text = td.turndown(clone.innerHTML).trim();
+      if (text === "") return "";
+
+      const indent = "  ".repeat(info.level - 1);
+      const ordinal = msoListOrdinal(el, info);
+      const prefix = isOrderedMsoMarker(markerText)
+        ? `${ordinal}. `
+        : `${td.options.bulletListMarker} `;
+
+      const isFirst = !msoListSibling(el, info, "previous");
+      const isLast = !msoListSibling(el, info, "next");
+      return (
+        (isFirst ? "\n\n" : "") +
+        indent +
+        prefix +
+        text.replace(/\n/g, `\n${indent}  `) +
+        "\n" +
+        (isLast ? "\n" : "")
+      );
     },
   });
 
@@ -190,16 +199,34 @@ interface MsoListInfo {
   level: number;
 }
 
+// Word glues a continuation suffix directly onto the class name with no
+// separator — MsoListParagraphCxSpFirst/Middle/Last, no word boundary in
+// between — for consecutive list paragraphs it treats as "connected" (to
+// suppress extra spacing between them). It's a paragraph-spacing optimization
+// unrelated to list structure: the mso-list style and marker span underneath
+// are identical to the plain MsoListParagraph form.
+const MSO_LIST_PARAGRAPH_CLASS =
+  /\bMsoListParagraph(?:CxSpFirst|CxSpMiddle|CxSpLast)?\b/i;
+
 /** Reads style="mso-list:l1 level2 lfo3" off a Word fake-list paragraph. */
 function msoListInfo(el: Element): MsoListInfo | null {
   if (!/^(P|DIV)$/.test(el.nodeName)) return null;
-  if (!/\bMsoListParagraph\b/i.test(el.getAttribute("class") ?? "")) {
+  if (!MSO_LIST_PARAGRAPH_CLASS.test(el.getAttribute("class") ?? "")) {
     return null;
   }
   const style = el.getAttribute("style") ?? "";
   const m = /mso-list:\s*(\S+)\s+level(\d+)/i.exec(style);
   return m === null ? null : { id: m[1], level: Number(m[2]) };
 }
+
+// KNOWN LIMITATION: requiring the exact same level means a nested sub-list
+// item breaks its parent level's run — e.g. "1. / (sub-item) / 2." sees the
+// top-level "2." as starting a brand-new list (previousElementSibling is the
+// level-2 item, not level-1), resetting its ordinal to "1" instead of
+// continuing the sequence. Fixing this properly means walking past — not just
+// rejecting — deeper-level siblings when computing adjacency/ordinal for a
+// shallower level. Flat single-level Word lists (by far the common case) are
+// unaffected; nested/outline lists may renumber incorrectly.
 
 /** The adjacent sibling in the same direction, if it belongs to the same list. */
 function msoListSibling(

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -235,9 +235,13 @@ function msoListSibling(
   direction: "previous" | "next",
 ): Element | null {
   const sib =
-    direction === "previous" ? el.previousElementSibling : el.nextElementSibling;
+    direction === "previous"
+      ? el.previousElementSibling
+      : el.nextElementSibling;
   const sibInfo = sib === null ? null : msoListInfo(sib);
-  return sibInfo !== null && sibInfo.id === info.id && sibInfo.level === info.level
+  return sibInfo !== null &&
+    sibInfo.id === info.id &&
+    sibInfo.level === info.level
     ? sib
     : null;
 }
@@ -271,19 +275,21 @@ function alignmentOf(el: HTMLElement): string | null {
 
 /** Strip Word's clipboard scaffolding before conversion. */
 function cleanWordHtml(html: string): string {
-  return html
-    // Downlevel-hidden conditional comments (<!--[if ...]>...<![endif]-->):
-    // this data (Word's XML/VML payloads) is never meant to render, so the
-    // whole block is removed.
-    .replace(/<!--\[if [\s\S]*?<!\[endif\]-->/gi, "")
-    // Downlevel-revealed conditional comments (<![if ...]>...<![endif]>, no
-    // <!--/--> wrapper): unlike the hidden form, this content DOES render —
-    // it's how Word marks its fake-list bullet/number spans — so only the
-    // marker tags themselves are stripped, never what's between them.
-    .replace(/<!\[(?:if\b[^\]]*|endif)\]>/gi, "")
-    .replace(/<\/?o:p[^>]*>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<xml[\s\S]*?<\/xml>/gi, "");
+  return (
+    html
+      // Downlevel-hidden conditional comments (<!--[if ...]>...<![endif]-->):
+      // this data (Word's XML/VML payloads) is never meant to render, so the
+      // whole block is removed.
+      .replace(/<!--\[if [\s\S]*?<!\[endif\]-->/gi, "")
+      // Downlevel-revealed conditional comments (<![if ...]>...<![endif]>, no
+      // <!--/--> wrapper): unlike the hidden form, this content DOES render —
+      // it's how Word marks its fake-list bullet/number spans — so only the
+      // marker tags themselves are stripped, never what's between them.
+      .replace(/<!\[(?:if\b[^\]]*|endif)\]>/gi, "")
+      .replace(/<\/?o:p[^>]*>/gi, "")
+      .replace(/<style[\s\S]*?<\/style>/gi, "")
+      .replace(/<xml[\s\S]*?<\/xml>/gi, "")
+  );
 }
 
 export function htmlToMarkdown(html: string): string {

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -55,6 +55,48 @@ function service(): TurndownService {
     },
   });
 
+  // Word's fake lists: a flat run of <p class=MsoListParagraph> (or the <div>
+  // form), each carrying its list id/level in style="mso-list:l1 level1 ..."
+  // and a throwaway marker glyph in a <span style="mso-list:Ignore"> child —
+  // there is no real <ul>/<ol>/<li> anywhere. This rule regroups consecutive
+  // siblings that share a list id+level into one logical list, numbering
+  // ordered items by position in the run (Word's own marker text is only used
+  // to tell ordered from unordered) and dropping the marker span entirely.
+  td.addRule("msoFakeList", {
+    filter: (node) => msoListInfo(node as Element) !== null,
+    replacement: (_content, node) => {
+      const el = node as HTMLElement;
+      const info = msoListInfo(el)!;
+
+      const clone = el.cloneNode(true) as HTMLElement;
+      const marker = Array.from(clone.querySelectorAll("span")).find((s) =>
+        /mso-list:\s*ignore/i.test(s.getAttribute("style") ?? ""),
+      );
+      const markerText = marker?.textContent?.trim() ?? "";
+      marker?.remove();
+
+      const text = td.turndown(clone.innerHTML).trim();
+      if (text === "") return "";
+
+      const indent = "  ".repeat(info.level - 1);
+      const ordinal = msoListOrdinal(el, info);
+      const prefix = isOrderedMsoMarker(markerText)
+        ? `${ordinal}. `
+        : `${td.options.bulletListMarker} `;
+
+      const isFirst = !msoListSibling(el, info, "previous");
+      const isLast = !msoListSibling(el, info, "next");
+      return (
+        (isFirst ? "\n\n" : "") +
+        indent +
+        prefix +
+        text.replace(/\n/g, `\n${indent}  `) +
+        "\n" +
+        (isLast ? "\n" : "")
+      );
+    },
+  });
+
   // Tables → GFM. turndown-plugin-gfm only converts a table whose first row is
   // a proper heading row (<th> / <thead>); Word emits header cells as bold
   // <td>s with no <thead>, so the plugin `keep`s the whole table as raw HTML.
@@ -143,6 +185,53 @@ function service(): TurndownService {
   return td;
 }
 
+interface MsoListInfo {
+  id: string;
+  level: number;
+}
+
+/** Reads style="mso-list:l1 level2 lfo3" off a Word fake-list paragraph. */
+function msoListInfo(el: Element): MsoListInfo | null {
+  if (!/^(P|DIV)$/.test(el.nodeName)) return null;
+  if (!/\bMsoListParagraph\b/i.test(el.getAttribute("class") ?? "")) {
+    return null;
+  }
+  const style = el.getAttribute("style") ?? "";
+  const m = /mso-list:\s*(\S+)\s+level(\d+)/i.exec(style);
+  return m === null ? null : { id: m[1], level: Number(m[2]) };
+}
+
+/** The adjacent sibling in the same direction, if it belongs to the same list. */
+function msoListSibling(
+  el: Element,
+  info: MsoListInfo,
+  direction: "previous" | "next",
+): Element | null {
+  const sib =
+    direction === "previous" ? el.previousElementSibling : el.nextElementSibling;
+  const sibInfo = sib === null ? null : msoListInfo(sib);
+  return sibInfo !== null && sibInfo.id === info.id && sibInfo.level === info.level
+    ? sib
+    : null;
+}
+
+/** 1-based position of `el` within its run of same-list-id-and-level siblings. */
+function msoListOrdinal(el: Element, info: MsoListInfo): number {
+  let ordinal = 1;
+  let sib = msoListSibling(el, info, "previous");
+  while (sib !== null) {
+    ordinal++;
+    sib = msoListSibling(sib, info, "previous");
+  }
+  return ordinal;
+}
+
+// Word's marker glyph tells ordered from unordered: "1.", "a)", "iv." are
+// ordered; a bare symbol (•, o, §, -, ▪ …) with no alphanumeric is a bullet.
+function isOrderedMsoMarker(marker: string): boolean {
+  return /^[0-9]+[.)]$|^[a-zA-Z][.)]$|^[ivxlcdm]+[.)]$/i.test(marker);
+}
+
 function alignmentOf(el: HTMLElement): string | null {
   const style = el.getAttribute("style") ?? "";
   const m = /text-align:\s*(center|right|justify)/i.exec(style);
@@ -156,7 +245,15 @@ function alignmentOf(el: HTMLElement): string | null {
 /** Strip Word's clipboard scaffolding before conversion. */
 function cleanWordHtml(html: string): string {
   return html
+    // Downlevel-hidden conditional comments (<!--[if ...]>...<![endif]-->):
+    // this data (Word's XML/VML payloads) is never meant to render, so the
+    // whole block is removed.
     .replace(/<!--\[if [\s\S]*?<!\[endif\]-->/gi, "")
+    // Downlevel-revealed conditional comments (<![if ...]>...<![endif]>, no
+    // <!--/--> wrapper): unlike the hidden form, this content DOES render —
+    // it's how Word marks its fake-list bullet/number spans — so only the
+    // marker tags themselves are stripped, never what's between them.
+    .replace(/<!\[(?:if\b[^\]]*|endif)\]>/gi, "")
     .replace(/<\/?o:p[^>]*>/gi, "")
     .replace(/<style[\s\S]*?<\/style>/gi, "")
     .replace(/<xml[\s\S]*?<\/xml>/gi, "");
@@ -209,13 +306,20 @@ export function htmlHasRichFormatting(html: string): boolean {
  * so it still gets converted. And text with no markdown characters is unaffected
  * by turndown's escaping anyway, so this only ever needs to catch the cases
  * where escaping would do harm.
+ *
+ * Word is one exception: its plain-text flavor renders list items as
+ * "•\titem" / "1.\titem" — a literal tab after the marker, which happens to
+ * satisfy CommonMark's list-marker grammar too. A human typing markdown by
+ * hand uses a space there, never a tab, so the list checks require one to
+ * avoid mistaking a Word list dump for markdown source and skipping its (very
+ * real) HTML conversion.
  */
 export function looksLikeMarkdown(text: string): boolean {
   return (
     /^ {0,3}#{1,6}\s/m.test(text) || // ATX heading
     /^ {0,3}>[ \t]/m.test(text) || // blockquote
-    /^ {0,3}[-*+][ \t]\S/m.test(text) || // bullet list
-    /^ {0,3}\d+[.)][ \t]\S/m.test(text) || // ordered list
+    /^ {0,3}[-*+] \S/m.test(text) || // bullet list
+    /^ {0,3}\d+[.)] \S/m.test(text) || // ordered list
     /^ {0,3}(?:```|~~~)/m.test(text) || // fenced code
     /\*\*[^\s*][^*]*\*\*|__[^\s_][^_]*__/.test(text) || // bold
     /\[[^\]\n]+\]\([^)\s]+\)/.test(text) || // link


### PR DESCRIPTION
## Summary
- Word's clipboard HTML represents lists as `<p class=MsoListParagraph>` paragraphs (no real `<ul>`/`<ol>`/`<li>`), with a throwaway marker glyph in a `<span style='mso-list:Ignore'>` and wrapped in a downlevel-revealed conditional comment (`<![if !supportLists]>...<![endif]>`, no `<!--`/`-->` wrapper) that the existing `cleanWordHtml` regex didn't strip. Added a turndown rule that regroups consecutive `MsoListParagraph` siblings by list id/level into proper GFM `- item` / `1. item` lists, dropping the marker span entirely.
- Separately, Word's plain-text clipboard flavor writes list markers as `"1.\titem"` (a literal tab), which satisfied `looksLikeMarkdown`'s ordered-list heuristic and caused the paste handler to treat the *entire* document as already-markdown-source — short-circuiting HTML conversion before either fix above (or anything else) could run. Tightened the heuristic to require a real space after the marker.

## Test plan
- [x] `npx vitest run` — 482/482 passing, including new regression tests for both fixes (`paste.test.ts`: Word fake-list conversion using the real captured clipboard structure, and the tab-vs-space `looksLikeMarkdown` false positive)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] Manually verified in the running dev app: pasted a real Word document (headings, bold/italic, bullet list, numbered list, blockquote-style pull quote, link, table) and confirmed the bullet/numbered lists now convert to real markdown while headings, bold/italic, the link, and the table remain unchanged