### PR TITLE
fix(export): normalize katex plugin default export against bad bundler interop

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -3,7 +3,7 @@ import taskLists from "markdown-it-task-lists";
 import sub from "markdown-it-sub";
 import sup from "markdown-it-sup";
 import footnotePlugin from "markdown-it-footnote";
-import katexPlugin from "@vscode/markdown-it-katex";
+import katexPluginImport from "@vscode/markdown-it-katex";
 import hljs from "highlight.js/lib/core";
 import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -20,6 +20,19 @@ import { PortabilityMode } from "./portability";
 import { ADMONITIONS, admonitionKind } from "./admonitions";
 import { isRemoteUrl, remoteImagesAllowed } from "./remoteimages";
 import { escapeDashes } from "./htmlcomment";
+
+// Vite's dependency pre-bundler has, at least once, mis-handled this
+// package's CJS default export — handing back the whole
+// `{ __esModule, default }` exports object instead of unwrapping to the
+// plugin function itself, so `md.use(katexPlugin, ...)` threw "plugin.apply
+// is not a function" in the dev server (never in Vitest, which doesn't go
+// through that bundling path). Normalizing here is robust to the bundler's
+// interop rather than depending on it.
+const katexPlugin: typeof katexPluginImport =
+  typeof katexPluginImport === "function"
+    ? katexPluginImport
+    : (katexPluginImport as unknown as { default: typeof katexPluginImport })
+        .default;
 
 // Curated language set for fenced-code highlighting in the PDF (core + these
 // keeps the bundle lean). registerLanguage also registers each language's


### PR DESCRIPTION
## Summary
- `renderDocumentHtml`'s PDF pagination measurement was throwing `TypeError: plugin.apply is not a function` on every load, from `md.use(katexPlugin, ...)` in `export.ts`.
- Traced it to Vite's dependency pre-bundler (Rolldown-based, Vite 8.2.1) mis-handling `@vscode/markdown-it-katex`'s CJS default export: the generated chunk does `export default require_dist()`, which returns the whole `{ __esModule, default }` CJS exports object rather than unwrapping to the plugin function — so `katexPlugin` was an object, not a callable, and `.apply` failed.
- This only reproduced through Vite's dev-server dependency-optimization path — `export.test.ts` (48 tests, including katex math rendering) all pass under Vitest, which resolves the module differently.
- Tried excluding the package from `optimizeDeps` first; that made it worse (raw CJS served directly, `SyntaxError: ... does not provide an export named 'default'`), since the package genuinely needs CJS→ESM conversion.
- Fixed at the import site instead: normalize to the function whether the bundler hands back the function directly or the wrapped exports object. Robust regardless of which bundling path resolves it.

## Test plan
- [x] `npx vitest run` — 477/477 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] Verified in the running dev app (with a cleared `node_modules/.vite/deps` cache to force re-optimization): the `plugin.apply is not a function` error no longer occurs on load

## Note
Fixing this surfaced a *separate*, pre-existing bug further down the same pagination path — a Paged.js internal error (`Cannot read properties of null (reading 'nextSibling')` in `Layout.findEndToken`/`Page.checkUnderflowAfterResize`), previously masked because the katex crash aborted pagination before Paged.js's chunker ran this far. Out of scope for this PR; tracking separately.