### PR TITLE
fix(pagination): disconnect Paged.js's ResizeObserver before tearing down preview containers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1149,8 +1149,19 @@ function teardownPreview(root: HTMLElement, previewer: Previewer | null) {
 }
 
 let printPreviewer: Previewer | null = null;
+// True for the entire duration of previewer.preview() in exportPdf(). Paged.js's
+// chunker is still actively creating/laying out Page objects during that
+// window (its render loop isn't cancelled just because our await is pending),
+// so tearing down through teardownPreview() then — e.g. Escape or the close
+// button firing mid-render — would call chunker.removePages(), which nulls
+// out each page's element/wrapper while the chunker's own loop is still
+// using them. That's a *different*, worse crash than the one teardownPreview
+// exists to prevent, and one that may not match PAGEDJS_NULL_READ. Guarding
+// here mirrors how runPagination() already refuses to overlap itself.
+let printPreviewRendering = false;
 
 function closePreview() {
+  if (printPreviewRendering) return;
   printPreview.hidden = true;
   teardownPreview(printRoot, printPreviewer);
   printPreviewer = null;
@@ -1163,6 +1174,10 @@ function closePreview() {
 }
 
 async function exportPdf() {
+  // A previous call's Paged.js render may still be in flight (its own loop
+  // isn't cancelled just because that earlier await settled our caller) —
+  // never tear down or re-render over it.
+  if (printPreviewRendering) return;
   // Never run two Paged.js layouts at once: cancel pending measurements and
   // wait out a running one before taking over the pipeline.
   window.clearTimeout(paginationTimer);
@@ -1189,12 +1204,15 @@ async function exportPdf() {
   source.innerHTML = html;
   const previewer = new Previewer();
   printPreviewer = previewer;
+  printPreviewRendering = true;
   try {
     await previewer.preview(source, [{ "monoleaf-print": css }], printRoot);
+    printPreviewRendering = false;
     printRoot.querySelectorAll("a[href]").forEach((a) => {
       a.setAttribute("title", "Opens in your default browser");
     });
   } catch (err) {
+    printPreviewRendering = false;
     closePreview();
     await showError(err);
   }
@@ -1475,7 +1493,11 @@ async function runPagination() {
       { title: "", author: "", date: "" },
       "#pagination-measure",
     );
-    teardownPreview(measureRoot, paginationPreviewer);
+    // paginationPreviewer is always null here — every path out of this
+    // function (including an early return above) goes through the finally
+    // block below, which tears the previous instance down and resets it.
+    // measureRoot is therefore already empty; this is just insurance.
+    measureRoot.innerHTML = "";
     const source = document.createElement("div");
     source.innerHTML = html;
     // Tracked immediately (not just after a successful preview) so the

--- a/src/main.ts
+++ b/src/main.ts
@@ -1127,9 +1127,33 @@ const pageMargin = document.getElementById("page-margin") as HTMLInputElement;
 const pageHeader = document.getElementById("page-header") as HTMLInputElement;
 const pageFooter = document.getElementById("page-footer") as HTMLInputElement;
 
+// Each Paged.js page keeps a ResizeObserver alive after `preview()` resolves
+// (it's how Paged.js re-paginates on reflow). Wiping a preview container's
+// innerHTML directly — without running Chunker#removePages() first, which is
+// what disconnects it — leaves that observer attached to nodes that no
+// longer exist; its callback still fires (via requestAnimationFrame) and
+// throws "Cannot read properties of null (reading 'nextSibling')" from deep
+// inside Paged.js's own layout code (matched by PAGEDJS_NULL_READ above).
+// Tearing down through the previewer instead of past it avoids the crash
+// rather than merely swallowing it — and, since a mid-pagination crash is
+// what leaves the live page indicator stuck on stale breaks (see
+// runPagination's catch below), this is also what keeps it in sync with a
+// real PDF export.
+function teardownPreview(root: HTMLElement, previewer: Previewer | null) {
+  try {
+    previewer?.chunker.removePages();
+  } catch {
+    // Best-effort: pagination tooling is never allowed to block on cleanup.
+  }
+  root.innerHTML = "";
+}
+
+let printPreviewer: Previewer | null = null;
+
 function closePreview() {
   printPreview.hidden = true;
-  printRoot.innerHTML = "";
+  teardownPreview(printRoot, printPreviewer);
+  printPreviewer = null;
   // Drop the stylesheets Paged.js injected into the document head.
   document
     .querySelectorAll("style[data-pagedjs-inserted-styles]")
@@ -1159,16 +1183,14 @@ async function exportPdf() {
       meta.author.trim() || (localStorage.getItem(AUTHOR_KEY)?.trim() ?? ""),
     date: meta.date.trim() || new Date().toLocaleDateString(),
   });
-  printRoot.innerHTML = "";
+  teardownPreview(printRoot, printPreviewer);
   printPreview.hidden = false;
   const source = document.createElement("div");
   source.innerHTML = html;
+  const previewer = new Previewer();
+  printPreviewer = previewer;
   try {
-    await new Previewer().preview(
-      source,
-      [{ "monoleaf-print": css }],
-      printRoot,
-    );
+    await previewer.preview(source, [{ "monoleaf-print": css }], printRoot);
     printRoot.querySelectorAll("a[href]").forEach((a) => {
       a.setAttribute("title", "Opens in your default browser");
     });
@@ -1391,6 +1413,7 @@ let paginationTimer: number | undefined;
 let paginationRunning = false;
 let paginationQueued = false;
 let lastMeasureKey = "";
+let paginationPreviewer: Previewer | null = null;
 
 function refreshPageIndicator() {
   if (
@@ -1452,10 +1475,14 @@ async function runPagination() {
       { title: "", author: "", date: "" },
       "#pagination-measure",
     );
-    measureRoot.innerHTML = "";
+    teardownPreview(measureRoot, paginationPreviewer);
     const source = document.createElement("div");
     source.innerHTML = html;
+    // Tracked immediately (not just after a successful preview) so the
+    // finally block below can always tear this instance down properly, even
+    // if preview() itself is what throws.
     const previewer = new Previewer();
+    paginationPreviewer = previewer;
     await previewer.preview(source, [{ "monoleaf-measure": css }], measureRoot);
     const { breaks, pages } = extractPageBreaks(measureRoot, view.state);
     knownBreaks = breaks;
@@ -1479,7 +1506,8 @@ async function runPagination() {
       pageIndicator.textContent = "";
     }
   } finally {
-    measureRoot.innerHTML = "";
+    teardownPreview(measureRoot, paginationPreviewer);
+    paginationPreviewer = null;
     document
       .querySelectorAll("style[data-pagedjs-inserted-styles]")
       .forEach((s) => s.remove());

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -36,6 +36,12 @@ declare module "pagedjs" {
   export class Previewer {
     constructor(options?: unknown);
     polisher: { destroy(): void };
+    // Each rendered page keeps a ResizeObserver alive (for reflow-triggered
+    // re-pagination) until Chunker#removePages() runs Page#destroy() on it.
+    // Clearing a preview container's DOM without calling this first leaves
+    // that observer attached to now-removed nodes — see the teardownPreview
+    // helper in main.ts.
+    chunker: { removePages(): void };
     preview(
       content?: unknown,
       stylesheets?: unknown[],


### PR DESCRIPTION
## Summary

The live in-editor page indicator/page-break decorations (`runPagination()`) could silently drift out of sync with what a real "Export PDF" (`exportPdf()`) actually produces.

Root cause: every Paged.js page registers a `ResizeObserver` on itself that stays alive after `preview()` resolves (that's the mechanism Paged.js uses to re-paginate on reflow). Both `runPagination()` and `exportPdf()` tore down their preview container by wiping `innerHTML` directly, without first calling `Chunker#removePages()` — the only thing that actually disconnects each page's observer (via each `Page`'s own `destroy()`). The now-orphaned observer's callback still fires shortly after (via `requestAnimationFrame`), walks DOM nodes that no longer exist, and throws:

```
TypeError: Cannot read properties of null (reading 'nextSibling')
 > nextSignificantNode pagedjs/src/utils/dom.js
 > nodeAfter pagedjs/src/utils/dom.js
 > Layout.findEndToken pagedjs/src/chunker/layout.js
 > Page.checkUnderflowAfterResize pagedjs/src/chunker/page.js
```

This is more than console noise: when the crash lands inside `runPagination()`'s own await chain (timing-dependent on document size/complexity), it's caught by the existing `isPagedjsInternalError` handling, which *deliberately* keeps the last known page breaks rather than blanking them (reasonable in isolation — see the comment at the catch site). `exportPdf()` has no equivalent fallback, so a real export computes fresh breaks independently of whatever the live indicator is currently (possibly staled) showing — which is what produces a mismatch between the two.

## Reproduction

Reproduced deterministically with purely synthetic filler text (Lorem ipsum, headings, a footnote, a table, a manual page break) — no real document content involved. Built a standalone harness exercising the exact same `renderDocumentHtml` → `buildPrintCss` → `Previewer.preview()` → teardown pipeline used by both `runPagination()` and `exportPdf()`:
- Without the fix: every one of 6 back-to-back passes resolved cleanly, then crashed ~15-20ms later from the orphaned observer (36 crashes total).
- With `chunker.removePages()` called before clearing the container: 0 crashes across the same 6 passes.

## Fix

- `src/shims.d.ts`: expose `Previewer.chunker.removePages()` in the hand-rolled type shim for the untyped `pagedjs` package.
- `src/main.ts`: new `teardownPreview(root, previewer)` helper that calls `previewer?.chunker.removePages()` before clearing `innerHTML`, wrapped in a best-effort try/catch. Wired into every teardown point for both preview containers: `closePreview()`, the top and `finally` of `runPagination()`, and the start of `exportPdf()`. Each previewer instance is tracked via module-scope `printPreviewer`/`paginationPreviewer`, set immediately on construction (not just after a successful `preview()`) so the correct instance can be torn down even when `preview()` itself is what throws.

## Test plan
- [x] `npx vitest run` — 477/477 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — clean
- [x] Standalone repro harness: confirmed clean A/B (36 crashes → 0) with the fix applied to the same Paged.js teardown pattern used in `main.ts`