### PR TITLE
fix(print): scope print/pagination CSS with a class Paged.js won't rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Monoleaf are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **PDF and print output now actually uses the page's intended typography.**
+  The stylesheet that sets the 11pt body size, heading sizes, line spacing,
+  justified text and code font was scoped to an element ID that Paged.js
+  rewrites internally, so none of those rules ever matched — printed
+  documents silently fell back to a 16px browser default instead. Exports
+  now render at the intended size, so a document has noticeably more text
+  per page and the printed page count may be lower than before.
+
 ## [1.1.0] - 2026-08-07
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -918,7 +918,7 @@
         <div id="update-notes-body"></div>
       </details>
     </div>
-    <div id="pagination-measure" aria-hidden="true"></div>
+    <div id="pagination-measure" class="ml-measure" aria-hidden="true"></div>
     <div id="print-preview" hidden>
       <div class="preview-toolbar">
         <span
@@ -928,7 +928,7 @@
         <button id="btn-print">Print / Save as PDF…</button>
         <button id="btn-close-preview">Close</button>
       </div>
-      <div id="print-root"></div>
+      <div id="print-root" class="ml-print"></div>
     </div>
     <dialog id="about-dialog" class="ml-dialog">
       <h2 id="about-title">Monoleaf</h2>

--- a/src/export.ts
+++ b/src/export.ts
@@ -597,7 +597,15 @@ export function contentExpression(
 export function buildPrintCss(
   cfg: PageConfig,
   vars: { title: string; author?: string; date: string },
-  root = "#print-root",
+  // A class, not an ID: Paged.js's Sheet.parse() rewrites every ID selector
+  // into `[data-id="…"]` (replaceIds), and data-id is only ever stamped onto
+  // *content* nodes it clones into the paginated output, never onto the
+  // render-target element itself. An ID-scoped root here would compile to a
+  // selector nothing in the paginated DOM ever matches, silently dropping
+  // every rule below (menu, headings, code font, justify — everything except
+  // the unscoped .ml-pagebreak and the @page block, which at-rules skip).
+  // Class selectors pass through untouched.
+  root = ".ml-print",
 ): string {
   const header = contentExpression(cfg.header, vars);
   const footer = contentExpression(cfg.footer, vars);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1491,7 +1491,7 @@ async function runPagination() {
     const css = buildPrintCss(
       cfg,
       { title: "", author: "", date: "" },
-      "#pagination-measure",
+      ".ml-measure",
     );
     // paginationPreviewer is always null here — every path out of this
     // function (including an early return above) goes through the finally


### PR DESCRIPTION
## Summary

`buildPrintCss`'s root selector defaulted to an ID (`#print-root` / `#pagination-measure`), but Paged.js's `Sheet.parse()` rewrites every ID selector into `[data-id="..."]` before layout, and `data-id` is only ever stamped onto content nodes it clones — never onto the render-target element itself. Every rule scoped to the root silently matched nothing:

- PDFs and the live pagination measurement rendered body text at the browser's inherited 16px instead of the intended 11pt.
- Headings, justify and the code font were equally inert.
- Only the `@page` block (an at-rule, exempt from the rewrite) ever took effect.

Switching the default to a class fixes it — verified directly against Paged.js's source (`Sheet.parse()` / `replaceIds`) and live in the running app (computed `font-size` on a paginated paragraph went from `16px` to `14.6667px`, i.e. exactly 11pt).

## Impact

This changes rendered PDF/print output for **every existing document** — text now renders at the intended size, so a document has noticeably more text per page and the printed page count may be lower than before. This is the fix's whole point, but worth calling out explicitly in review since it's a visible behavior change, not just an internal refactor.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, `npm run format:check`, `npm test` — all pass on this commit in isolation (verified via a temporary `git stash --keep-index` before committing, not just on the combined branch)
- [x] Added test: `buildPrintCss` scopes with a class, not an ID Paged.js would rewrite and orphan (`src/export.ts` — held for the follow-up PR, since the test file also carries unrelated font-feature test additions not part of this fix)
- [x] Manually reproduced the bug and the fix live in the running app via the WebView2 DevTools protocol: confirmed `getComputedStyle` on a paginated paragraph reports 16px before this change's logic and 14.6667px (11pt) after