### PR TITLE
fix(commands): stop empty inline-toggle pairs from stacking on repeated clicks

### DIFF
--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -109,6 +109,65 @@ describe("inline toggles", () => {
     expect(run(toggleSuperscript, "E=mc^2^", 5).doc).toBe("E=mc2");
   });
 
+  // A second click with no typing in between lands the cursor exactly
+  // between two marker pairs the first click already inserted ("**|**").
+  // CommonMark never parses that as a real StrongEmphasis/Emphasis/etc.
+  // node (delimiters need non-empty content), so naively falling through to
+  // the wrap branch would stack another pair instead of removing the empty
+  // one — turning one stray click into a permanent "****" artifact.
+  describe("toggling twice on empty content removes the pair instead of stacking", () => {
+    it("bold", () => {
+      const once = run(toggleBold, "x ", 2);
+      expect(once.doc).toBe("x ****");
+      const twice = run(toggleBold, once.doc, 4);
+      expect(twice.doc).toBe("x ");
+    });
+
+    it("italic", () => {
+      const once = run(toggleItalic, "x ", 2);
+      expect(once.doc).toBe("x **");
+      const twice = run(toggleItalic, once.doc, 3);
+      expect(twice.doc).toBe("x ");
+    });
+
+    it("strikethrough", () => {
+      const once = run(toggleStrikethrough, "x ", 2);
+      expect(once.doc).toBe("x ~~~~");
+      const twice = run(toggleStrikethrough, once.doc, 4);
+      expect(twice.doc).toBe("x ");
+    });
+
+    it("inline code", () => {
+      const once = run(toggleInlineCode, "x ", 2);
+      expect(once.doc).toBe("x ``");
+      const twice = run(toggleInlineCode, once.doc, 3);
+      expect(twice.doc).toBe("x ");
+    });
+
+    it("subscript", () => {
+      const once = run(toggleSubscript, "x ", 2);
+      expect(once.doc).toBe("x ~~");
+      const twice = run(toggleSubscript, once.doc, 3);
+      expect(twice.doc).toBe("x ");
+    });
+
+    it("superscript", () => {
+      const once = run(toggleSuperscript, "x ", 2);
+      expect(once.doc).toBe("x ^^");
+      const twice = run(toggleSuperscript, once.doc, 3);
+      expect(twice.doc).toBe("x ");
+    });
+  });
+
+  it("does not corrupt an empty strikethrough when subscript is toggled inside it (shared marker character)", () => {
+    // "~~~~" is an empty strikethrough, not two empty subscripts — since
+    // "~" is a run-prefix of "~~", the empty-pair fix must not mistake the
+    // inner two characters for a standalone empty subscript pair and delete
+    // half of the strikethrough's real markers.
+    const r = run(toggleSubscript, "~~~~", 2);
+    expect(r.doc).toContain("~~~~");
+  });
+
   it("insert equation wraps a selection in $…$", () => {
     expect(run(insertMath, "abc", 0, 3).doc).toBe("$abc$");
   });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -72,6 +72,11 @@ function enclosing(
   return null;
 }
 
+/** The single character at `pos`, or "" at a document boundary. */
+function charAt(state: EditorState, pos: number): string {
+  return pos < 0 || pos >= state.doc.length ? "" : state.sliceDoc(pos, pos + 1);
+}
+
 /** Toggle an inline wrapper construct like **bold** or `code`. */
 function toggleInline(
   nodeName: string,
@@ -94,6 +99,42 @@ function toggleInline(
           changes: [
             { from: first.from, to: first.to },
             { from: last.from, to: last.to },
+          ],
+          userEvent: "delete.format",
+        }),
+      );
+      return true;
+    }
+
+    // An empty marker pair sitting right at the cursor — toggled on, then
+    // toggled again without typing in between — never parses as `nodeName`:
+    // CommonMark requires non-empty content between emphasis delimiters, so
+    // `enclosing` above can never find it. Left to the wrap branch below,
+    // every repeated click would stack another marker pair around the same
+    // empty spot ("**|**" -> "****|****" -> ...) instead of removing it.
+    // Same fix toggleHtmlWrap already applies via a direct before/after
+    // string check, adapted here for markdown's repeated-character markers.
+    if (
+      range.from === range.to &&
+      state.sliceDoc(Math.max(0, range.from - marker.length), range.from) ===
+        marker &&
+      state.sliceDoc(
+        range.to,
+        Math.min(state.doc.length, range.to + marker.length),
+      ) === marker &&
+      // Guard against a marker that is a run-prefix of a longer one built
+      // from the same character (subscript "~" vs strikethrough "~~"): if
+      // one more of that character sits just outside the matched run, this
+      // is the middle of a longer pair, not a standalone empty one — leave
+      // it alone rather than deleting half of an unrelated strikethrough.
+      charAt(state, range.from - marker.length - 1) !== marker[0] &&
+      charAt(state, range.to + marker.length) !== marker[0]
+    ) {
+      dispatch(
+        state.update({
+          changes: [
+            { from: range.from - marker.length, to: range.from },
+            { from: range.to, to: range.to + marker.length },
           ],
           userEvent: "delete.format",
         }),


### PR DESCRIPTION
## Summary
- Bold/Italic/Strikethrough/Inline-code/Subscript/Superscript all share `toggleInline()`, which decides whether to unwrap by looking for a parsed syntax node (StrongEmphasis/Emphasis/etc.) at the cursor.
- CommonMark never parses an empty delimiter pair (`**|**`, nothing typed in between) as a real node, so toggling the same mark twice with nothing typed in between never finds anything to unwrap — it just wraps again, stacking indefinitely (`**|**` → `****|****` → `********|********`...).
- `toggleHtmlWrap` (Underline/Highlight) already avoided this with a direct before/after string check instead of relying on the parser; `toggleInline` gets the same check here.
- Guards against the one extra wrinkle that introduces: Subscript's `~` is a character-run prefix of Strikethrough's `~~`, so a naive check could shave a stray `~` off an unrelated empty strikethrough pair.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (519 tests passing, including 8 new tests covering the toggle-twice-removes-empty-pair behavior across all 6 affected commands plus the subscript/strikethrough collision guard)
- [x] `npm run lint`
- [x] `npm run format:check`