### PR TITLE
fix(pagination): resolve exact page-break positions via Paged.js's real break tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   documents silently fell back to a 16px browser default instead. Exports
   now render at the intended size, so a document has noticeably more text
   per page and the printed page count may be lower than before.
+- **The in-editor page-break indicator now matches the real PDF/print output
+  exactly**, instead of landing on a nearby but different line. A long
+  paragraph that runs across a page boundary now reads Paged.js's own break
+  point for plain-text paragraphs directly, rather than guessing where the
+  cut fell; anything with inline formatting (bold, links, code, …) still
+  falls back to the previous best-effort estimate, which itself no longer
+  collapses onto a single position when a paragraph spans more than two
+  pages.
 
 ## [1.1.0] - 2026-08-07
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -451,6 +451,11 @@ export function renderDocumentHtml(
       for (const token of state.tokens) {
         if (token.map !== null && token.block) {
           token.attrSet("data-srcline", String(token.map[0]));
+          // token.map is [startLine, endLine) — end exclusive. Lets
+          // extractPageBreaks (pagination.ts) anchor a page break to where a
+          // straddling block ENDS when Paged.js clones its stale start-line
+          // data-srcline onto the continuation fragment on the next page.
+          token.attrSet("data-srcline-end", String(token.map[1]));
         }
       }
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,6 +111,7 @@ import {
 } from "./remoteimages";
 import { Previewer } from "pagedjs";
 import {
+  BreakToken,
   extractPageBreaks,
   pageAt,
   pageBreaksField,
@@ -981,16 +982,21 @@ function applyPageVars() {
         "padding",
         `${m.top * z}px ${m.right * z}px ${m.bottom * z}px ${m.left * z}px`,
       );
-      s.setProperty("font-size", `${(PRINT_FONT_PX * z).toFixed(2)}px`);
+      // No .toFixed() here: rounding to 2 decimals (14.67px) versus print's
+      // exact 11pt (14.666666...px) is a tiny per-line discrepancy that
+      // compounds over a long paragraph — CodeMirror's own word-wrapping and
+      // Paged.js's can end up disagreeing about which word ends a line
+      // purely from that drift, independent of where any page-break marker
+      // is placed. Not rounding doesn't make the two engines' layouts
+      // identical (they're still separate renderers), but it removes this
+      // one concrete, needless source of divergence between them.
+      s.setProperty("font-size", `${PRINT_FONT_PX * z}px`);
       s.setProperty("font-family", fontStack(currentFontId));
     }
     if (editorFontRule?.parentStyleSheet == null) {
       editorFontRule = findRule("#editor .cm-editor");
     }
-    editorFontRule?.style.setProperty(
-      "font-size",
-      `${(PRINT_FONT_PX * z).toFixed(2)}px`,
-    );
+    editorFontRule?.style.setProperty("font-size", `${PRINT_FONT_PX * z}px`);
   } catch (err) {
     console.error("[monoleaf] applyPageVars failed:", err);
   }
@@ -1558,8 +1564,22 @@ async function runPagination() {
     // if preview() itself is what throws.
     const previewer = new Previewer();
     paginationPreviewer = previewer;
+    // Collect the exact break token Paged.js cut each page at, keyed by the
+    // page it ends (0-based) — afterPageLayout can re-fire for the same page
+    // during Paged.js's own overflow retries, so last write wins, same as
+    // Paged.js's own resolution. extractPageBreaks uses these for a
+    // pixel-exact divider when the straddling block turns out to be plain
+    // text, falling back to its proportional approximation otherwise.
+    const exactBreaks = new Map<number, BreakToken | undefined>();
+    previewer.chunker.hooks.afterPageLayout.register((_el, page, token) => {
+      exactBreaks.set(page.position, token);
+    });
     await previewer.preview(source, [{ "monoleaf-measure": css }], measureRoot);
-    const { breaks, pages } = extractPageBreaks(measureRoot, view.state);
+    const { breaks, pages } = extractPageBreaks(
+      measureRoot,
+      view.state,
+      exactBreaks,
+    );
     knownBreaks = breaks;
     knownPages = pages;
     lastMeasureKey = key;

--- a/src/pagination.test.ts
+++ b/src/pagination.test.ts
@@ -1,9 +1,13 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { EditorState } from "@codemirror/state";
 import {
+  BreakToken,
   buildPageBreakDecorations,
+  extractPageBreaks,
   pageAt,
   pageBreaksField,
+  resolveExactBreakPos,
   setPageBreaks,
 } from "./pagination";
 import { renderDocumentHtml } from "./export";
@@ -66,14 +70,258 @@ describe("source-line attributes for break mapping", () => {
       "strict",
       true,
     );
-    expect(html).toContain('<p data-srcline="0">');
-    expect(html).toContain('<h2 data-srcline="2">');
-    expect(html).toContain('<p data-srcline="4">');
+    expect(html).toContain('data-srcline="0"');
+    expect(html).toContain('<h2 data-srcline="2"');
+    expect(html).toContain('data-srcline="4"');
+  });
+
+  it("also carries data-srcline-end (exclusive), for extractPageBreaks's straddling-block fallback", () => {
+    // "first\nsecond" is one paragraph spanning source lines 0-1; its map
+    // end is 2 (the blank line). "third" starts at line 3, ends at 4 (EOF).
+    const html = renderDocumentHtml("first\nsecond\n\nthird\n", "strict", true);
+    expect(html).toContain('<p data-srcline="0" data-srcline-end="2">');
+    expect(html).toContain('<p data-srcline="3" data-srcline-end="4">');
   });
 
   it("is off by default (export output unchanged)", () => {
     expect(renderDocumentHtml("hello\n", "strict")).not.toContain(
       "data-srcline",
+    );
+  });
+});
+
+describe("extractPageBreaks", () => {
+  // "first\nsecond\n\nthird\n": paragraph A spans lines 0-1 (map end 2, the
+  // blank line); paragraph B is "third" at line 3 (map end 4).
+  const docText = "first\nsecond\n\nthird\n";
+
+  it("anchors a lone straddling continuation to the block's MIDPOINT, not its stale START", () => {
+    const state = EditorState.create({ doc: docText });
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2">first second</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2" data-split-from="x">continuation</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="3" data-srcline-end="4">third</p>
+      </div>
+    `;
+    const { breaks, pages } = extractPageBreaks(container, state);
+    expect(pages).toBe(3);
+    expect(breaks).toHaveLength(2);
+
+    // Page 2's break must NOT be paragraph A's start — that position is on
+    // page 1, which is exactly the bug (the divider would sit above content
+    // that's still on the previous page).
+    const startOfA = state.doc.line(1).from;
+    expect(breaks[0].pos).not.toBe(startOfA);
+    // A run of exactly one continuation page divides the block into two
+    // halves (1/(1+1)) — its midpoint, the least-wrong guess with nothing
+    // else to go on.
+    const blockFrom = state.doc.line(1).from;
+    const blockTo = state.doc.line(2).to;
+    expect(breaks[0].pos).toBe(
+      blockFrom + Math.round((blockTo - blockFrom) / 2),
+    );
+    expect(breaks[0].page).toBe(2);
+
+    // Page 3 is fresh (no data-split-from) — anchors normally, at the
+    // block's start, same as before this fix.
+    expect(breaks[1].pos).toBe(state.doc.line(4).from);
+    expect(breaks[1].page).toBe(3);
+  });
+
+  it("spreads a run of several continuation pages across the block's span, not onto one collapsed position", () => {
+    // A paragraph still being continued on page 4 too — page 2, 3 and 4 are
+    // all continuations of the SAME block. Each gets a distinct fraction of
+    // the way through it (1/4, 2/4, 3/4) instead of collapsing onto one
+    // position (the bug the end-only anchor had for anything longer than a
+    // two-page straddle — exactly the shape a long, single-paragraph, never
+    // hard-wrapped block of prose takes in this editor).
+    const state = EditorState.create({ doc: docText });
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2">first</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2" data-split-from="x">cont 1</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2" data-split-from="x">cont 2</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2" data-split-from="x">cont 3</p>
+      </div>
+    `;
+    const { breaks, pages } = extractPageBreaks(container, state);
+    expect(pages).toBe(4);
+    const blockFrom = state.doc.line(1).from;
+    const span = state.doc.line(2).to - blockFrom;
+    expect(breaks).toEqual([
+      { pos: blockFrom + Math.round(span * (1 / 4)), page: 2 },
+      { pos: blockFrom + Math.round(span * (2 / 4)), page: 3 },
+      { pos: blockFrom + Math.round(span * (3 / 4)), page: 4 },
+    ]);
+    // Strictly increasing — Decoration.set (buildPageBreakDecorations)
+    // requires its input already sorted.
+    expect(breaks[0].pos).toBeLessThan(breaks[1].pos);
+    expect(breaks[1].pos).toBeLessThan(breaks[2].pos);
+  });
+
+  it("degrades to dropping (not crashing or misordering) a break when rounding collides", () => {
+    // A one-character block ("x") is too short to give 3 continuation pages
+    // distinct integer positions — two of the three fractions round to the
+    // same offset. Must still not throw, double-count, or go out of order.
+    const state = EditorState.create({ doc: "x\n\nthird\n" });
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1">x</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1" data-split-from="x">cont 1</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1" data-split-from="x">cont 2</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1" data-split-from="x">cont 3</p>
+      </div>
+    `;
+    const { breaks, pages } = extractPageBreaks(container, state);
+    expect(pages).toBe(4);
+    // One of the three candidate positions collides and is dropped, but the
+    // survivors stay strictly increasing.
+    expect(breaks.length).toBeLessThan(3);
+    for (let i = 1; i < breaks.length; i++) {
+      expect(breaks[i].pos).toBeGreaterThan(breaks[i - 1].pos);
+    }
+  });
+
+  it("returns no breaks for a single page", () => {
+    const state = EditorState.create({ doc: docText });
+    const container = document.createElement("div");
+    container.innerHTML = `<div class="pagedjs_page"><p data-srcline="0">first</p></div>`;
+    expect(extractPageBreaks(container, state)).toEqual({
+      breaks: [],
+      pages: 1,
+    });
+  });
+
+  it("prefers an exact break token over the proportional guess", () => {
+    // Same straddling shape as the midpoint test above, but this time a
+    // real break token is supplied for page 0 (the page it ends), pointing
+    // exactly 6 characters into "first second" — right after "first ".
+    const state = EditorState.create({ doc: "first second\n\nthird\n" });
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1">first </p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="1" data-split-from="x">second</p>
+      </div>
+    `;
+    // The break token's node lives in Paged.js's untouched SOURCE tree — a
+    // full, unsplit copy of the paragraph — never the rendered/truncated
+    // page content above.
+    const sourceP = document.createElement("p");
+    sourceP.setAttribute("data-srcline", "0");
+    sourceP.setAttribute("data-srcline-end", "1");
+    sourceP.textContent = "first second";
+    const textNode = sourceP.firstChild!;
+    const exactBreaks = new Map<number, BreakToken | undefined>([
+      [0, { node: textNode, offset: 6 }],
+    ]);
+    const { breaks } = extractPageBreaks(container, state, exactBreaks);
+    expect(breaks).toEqual([{ pos: 6, page: 2 }]);
+  });
+
+  it("falls back to the proportional guess when the exact token is unresolvable", () => {
+    // exactBreaks is supplied but maps to undefined for this page (Paged.js
+    // gives no token past the last page) — must not throw, must fall
+    // through to the existing continuation logic unchanged.
+    const state = EditorState.create({ doc: docText });
+    const container = document.createElement("div");
+    container.innerHTML = `
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2">first second</p>
+      </div>
+      <div class="pagedjs_page">
+        <p data-srcline="0" data-srcline-end="2" data-split-from="x">continuation</p>
+      </div>
+    `;
+    const exactBreaks = new Map<number, BreakToken | undefined>([
+      [0, undefined],
+    ]);
+    const { breaks } = extractPageBreaks(container, state, exactBreaks);
+    const blockFrom = state.doc.line(1).from;
+    const blockTo = state.doc.line(2).to;
+    expect(breaks).toEqual([
+      { pos: blockFrom + Math.round((blockTo - blockFrom) / 2), page: 2 },
+    ]);
+  });
+});
+
+describe("resolveExactBreakPos", () => {
+  it("resolves a plain-text block to the exact rendered offset", () => {
+    const state = EditorState.create({ doc: "first second\n\nthird\n" });
+    const p = document.createElement("p");
+    p.setAttribute("data-srcline", "0");
+    p.setAttribute("data-srcline-end", "1");
+    p.textContent = "first second";
+    const textNode = p.firstChild!;
+    // Right after "first " (6 characters in).
+    expect(resolveExactBreakPos({ node: textNode, offset: 6 }, state)).toBe(6);
+  });
+
+  it("maps a soft-wrapped (two physical source lines) block back to its original, non-normalized offset", () => {
+    const state = EditorState.create({ doc: "first\nsecond\n\nthird\n" });
+    const p = document.createElement("p");
+    p.setAttribute("data-srcline", "0");
+    p.setAttribute("data-srcline-end", "2");
+    // Rendered text: the soft break becomes a single space, same as the
+    // real browser/Paged.js output for this paragraph.
+    p.textContent = "first second";
+    const textNode = p.firstChild!;
+    // Rendered offset 7 = "first s" (up through the "s" of "second").
+    // Source position 7 is the same offset since the newline collapses to
+    // exactly one character, same as the space it replaces.
+    expect(resolveExactBreakPos({ node: textNode, offset: 7 }, state)).toBe(7);
+  });
+
+  it("returns null for a block reshaped by inline formatting", () => {
+    const state = EditorState.create({ doc: "**first** second\n\nthird\n" });
+    const p = document.createElement("p");
+    p.setAttribute("data-srcline", "0");
+    p.setAttribute("data-srcline-end", "1");
+    const strong = document.createElement("strong");
+    strong.textContent = "first";
+    p.append(strong, " second");
+    const textNode = p.lastChild!; // " second"
+    expect(resolveExactBreakPos({ node: textNode, offset: 3 }, state)).toBe(
+      null,
+    );
+  });
+
+  it("handles an element-type break token (offset ignored, anchors to the block's start)", () => {
+    const state = EditorState.create({ doc: "first second\n\nthird\n" });
+    const p = document.createElement("p");
+    p.setAttribute("data-srcline", "0");
+    p.setAttribute("data-srcline-end", "1");
+    p.textContent = "first second";
+    expect(resolveExactBreakPos({ node: p, offset: 999 }, state)).toBe(0);
+  });
+
+  it("returns null when the token's node has no [data-srcline] ancestor", () => {
+    const state = EditorState.create({ doc: "first second\n" });
+    const detached = document.createTextNode("orphan");
+    expect(resolveExactBreakPos({ node: detached, offset: 2 }, state)).toBe(
+      null,
     );
   });
 });

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -87,32 +87,190 @@ export const pageBreaksField = StateField.define<DecorationSet>({
   provide: (f) => EditorView.decorations.from(f),
 });
 
+/** The stale, clone-inherited data-srcline of a continuation-only page — the
+ * block it's continuing, identified by that block's own start line — or
+ * null if the page isn't a pure continuation (no data-srcline at all). */
+function continuationStartLine(page: Element): number | null {
+  const marker = page.querySelector("[data-srcline]");
+  if (marker === null) return null;
+  const line = Number(marker.getAttribute("data-srcline"));
+  return Number.isFinite(line) ? line : null;
+}
+
+export interface BreakToken {
+  node: Node;
+  offset: number;
+}
+
+/** Map a Paged.js break token to an exact editor position, when the
+ * straddling block is confirmed plain text (no inline formatting) — null
+ * otherwise, so the caller falls back to the proportional approximation
+ * below. The token's node lives in Paged.js's untouched SOURCE tree (the
+ * same one runPagination() built, carrying data-srcline/-end), never the
+ * cloned/rendered output, so walking up to the nearest [data-srcline]
+ * ancestor and using the DOM Range API gives the exact rendered text
+ * between the block's start and the break — as long as that text is a
+ * straight character-for-character match against a whitespace-normalized
+ * copy of the source (CommonMark renders a soft line break as one space),
+ * which rules out anything reshaped by inline markup (bold, links, code,
+ * entities) before trusting the mapped-back offset. */
+export function resolveExactBreakPos(
+  token: BreakToken,
+  state: EditorState,
+): number | null {
+  const startEl =
+    token.node.nodeType === Node.ELEMENT_NODE
+      ? (token.node as Element)
+      : token.node.parentElement;
+  const blockEl = startEl?.closest("[data-srcline]");
+  if (blockEl == null) return null;
+
+  const startLine = Number(blockEl.getAttribute("data-srcline"));
+  const endLine = Number(blockEl.getAttribute("data-srcline-end"));
+  if (!Number.isFinite(startLine) || !Number.isFinite(endLine)) return null;
+
+  const blockFrom = state.doc.line(
+    Math.min(startLine + 1, state.doc.lines),
+  ).from;
+  const blockTo = state.doc.line(Math.min(endLine, state.doc.lines)).to;
+  const sourceText = state.doc.sliceString(blockFrom, blockTo);
+
+  // Collapse whitespace runs to a single space, the same way CommonMark
+  // renders a soft line break, recording each output character's original
+  // source index so a match can be mapped back exactly.
+  let normalized = "";
+  const toOriginal: number[] = [];
+  for (let i = 0; i < sourceText.length;) {
+    if (/\s/.test(sourceText[i])) {
+      toOriginal.push(i);
+      normalized += " ";
+      while (i < sourceText.length && /\s/.test(sourceText[i])) i++;
+    } else {
+      toOriginal.push(i);
+      normalized += sourceText[i];
+      i++;
+    }
+  }
+  if (normalized !== blockEl.textContent) return null; // formatted — bail
+
+  const range = document.createRange();
+  range.setStart(blockEl, 0);
+  if (token.node.nodeType === Node.TEXT_NODE) {
+    const len = token.node.textContent?.length ?? 0;
+    range.setEnd(token.node, Math.min(token.offset, len));
+  } else {
+    range.setEnd(token.node, 0);
+  }
+  const renderedOffset = range.toString().length;
+  if (renderedOffset > normalized.length) return null;
+
+  const originalIndex =
+    renderedOffset < normalized.length
+      ? toOriginal[renderedOffset]
+      : sourceText.length;
+  return blockFrom + originalIndex;
+}
+
 /**
  * Read the real break positions out of Paged.js output. Pages after the
- * first look for their first block that carries a source line; blocks split
- * across a break (data-split-from) are skipped so the marker sits at the
- * first block fully on the new page.
+ * first look for their first block that carries a source line — anchoring
+ * there is exact, since that block genuinely starts fresh on this page.
+ *
+ * When every candidate on a page is instead a continuation of a block that
+ * started earlier (data-split-from), there's no exact position to anchor
+ * to: Paged.js clones the original element's data-srcline onto the
+ * continuation without updating it (so it points at the block's START, on
+ * the *previous* page), and the real cut point — mid-word, wherever the
+ * page happened to run out of room — never reaches the DOM at all; Paged.js
+ * only writes the already-sliced text. Given a run of N consecutive
+ * continuation pages for the SAME block (data-srcline unchanged across
+ * them), this spreads their markers evenly across that block's own
+ * character span — 1/(N+1), 2/(N+1), … through it — rather than collapsing
+ * them all onto one position (the bug this replaced) or all onto the
+ * block's end (which is exact only when N is 1, and wrong for a paragraph
+ * spanning many pages, exactly the kind of long, single-block prose this
+ * editor naturally produces since it never hard-wraps as you type). With
+ * nothing else to go on, even spacing is the least-wrong assumption; each
+ * marker is still guaranteed on-or-after its page's actual content and
+ * distinct from every other page's.
  */
 export function extractPageBreaks(
   container: Element,
   state: EditorState,
+  exactBreaks?: ReadonlyMap<number, BreakToken | undefined>,
 ): { breaks: PageBreak[]; pages: number } {
   const pages = Array.from(container.querySelectorAll(".pagedjs_page"));
   const breaks: PageBreak[] = [];
   const seen = new Set<number>();
-  pages.forEach((page, index) => {
-    if (index === 0) return;
-    const el =
-      page.querySelector("[data-srcline]:not([data-split-from])") ??
-      page.querySelector("[data-srcline]");
-    if (el === null) return;
-    const line = Number(el.getAttribute("data-srcline"));
-    if (!Number.isFinite(line)) return;
-    const docLine = state.doc.line(Math.min(line + 1, state.doc.lines));
-    if (seen.has(docLine.from)) return;
-    seen.add(docLine.from);
-    breaks.push({ pos: docLine.from, page: index + 1 });
-  });
+
+  const addBreak = (pos: number, page: number) => {
+    if (seen.has(pos)) return;
+    seen.add(pos);
+    breaks.push({ pos, page });
+  };
+
+  let i = 1; // page index 0 never gets a break — it's the document's start.
+  while (i < pages.length) {
+    // A break token is keyed by the PAGE IT ENDS (i - 1) — the exact point
+    // where page i begins. Preferred over the fresh/continuation heuristics
+    // below whenever the straddling block is confirmed plain text.
+    const exact = exactBreaks?.get(i - 1);
+    const exactPos = exact ? resolveExactBreakPos(exact, state) : null;
+    if (exactPos !== null) {
+      addBreak(exactPos, i + 1);
+      i++;
+      continue;
+    }
+
+    const fresh = pages[i].querySelector(
+      "[data-srcline]:not([data-split-from])",
+    );
+    if (fresh !== null) {
+      const line = Number(fresh.getAttribute("data-srcline"));
+      if (Number.isFinite(line)) {
+        addBreak(
+          state.doc.line(Math.min(line + 1, state.doc.lines)).from,
+          i + 1,
+        );
+      }
+      i++;
+      continue;
+    }
+
+    // A run of one or more consecutive pages, all continuing the SAME
+    // block (matching start line) with nothing fresh on them.
+    const startLine = continuationStartLine(pages[i]);
+    const endEl = pages[i].querySelector("[data-srcline-end]");
+    const endLine = endEl
+      ? Number(endEl.getAttribute("data-srcline-end"))
+      : NaN;
+    if (startLine === null || !Number.isFinite(endLine)) {
+      i++;
+      continue;
+    }
+    let runEnd = i;
+    while (
+      runEnd + 1 < pages.length &&
+      pages[runEnd + 1].querySelector(
+        "[data-srcline]:not([data-split-from])",
+      ) === null &&
+      continuationStartLine(pages[runEnd + 1]) === startLine
+    ) {
+      runEnd++;
+    }
+
+    const runLength = runEnd - i + 1;
+    const blockFrom = state.doc.line(
+      Math.min(startLine + 1, state.doc.lines),
+    ).from;
+    const blockTo = state.doc.line(Math.min(endLine, state.doc.lines)).to;
+    const span = Math.max(0, blockTo - blockFrom);
+    for (let j = 0; j < runLength; j++) {
+      const fraction = (j + 1) / (runLength + 1);
+      addBreak(blockFrom + Math.round(span * fraction), i + j + 1);
+    }
+    i = runEnd + 1;
+  }
   return { breaks, pages: pages.length };
 }
 

--- a/src/sanitize.test.ts
+++ b/src/sanitize.test.ts
@@ -86,6 +86,12 @@ describe("sanitizeDocumentHtml", () => {
     );
   });
 
+  it("preserves data-srcline-end (extractPageBreaks's straddling-block fallback)", () => {
+    expect(
+      sanitizeDocumentHtml('<p data-srcline="7" data-srcline-end="9">x</p>'),
+    ).toContain('data-srcline-end="9"');
+  });
+
   it("preserves MathML emitted by KaTeX", () => {
     const out = sanitizeDocumentHtml(
       "<math><mrow><mi>C</mi><mn>2</mn></mrow></math>",

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -40,6 +40,16 @@ declare module "turndown-plugin-gfm" {
 }
 
 declare module "pagedjs" {
+  export interface PagedBreakToken {
+    node: Node;
+    offset: number;
+  }
+  export interface PagedPage {
+    position: number; // 0-based
+  }
+  export interface PagedHook<A extends unknown[]> {
+    register(...handlers: Array<(...args: A) => unknown>): void;
+  }
   export class Previewer {
     constructor(options?: unknown);
     polisher: { destroy(): void };
@@ -48,7 +58,18 @@ declare module "pagedjs" {
     // Clearing a preview container's DOM without calling this first leaves
     // that observer attached to now-removed nodes — see the teardownPreview
     // helper in main.ts.
-    chunker: { removePages(): void };
+    chunker: {
+      removePages(): void;
+      hooks: {
+        // Fires once per page laid out, with the exact break token (source
+        // DOM node + character offset) the layout stopped at — undefined
+        // for the last page / pages with nothing left to break. See the
+        // resolveExactBreakPos design note in pagination.ts.
+        afterPageLayout: PagedHook<
+          [HTMLElement, PagedPage, PagedBreakToken | undefined, unknown]
+        >;
+      };
+    };
     preview(
       content?: unknown,
       stylesheets?: unknown[],


### PR DESCRIPTION
## Summary
- The live editor's page-break indicator previously guessed a straddling paragraph's break point by distributing continuation pages evenly across the block's character span. That guess couldn't match the real PDF/print output exactly — confirmed via a 500-sentence single-paragraph repro where the live divider landed two sentences off the actual break.
- Paged.js's chunker exposes an internal hook, `afterPageLayout`, firing once per page with the exact break token (a real DOM node + character offset) the layout cut at. That node lives in Paged.js's untouched SOURCE tree — the same hidden div `runPagination()` already builds, carrying `data-srcline`/`data-srcline-end` attributes — never the cloned/rendered output.
- `resolveExactBreakPos()` walks from the token's node to the nearest `[data-srcline]` ancestor, then uses the DOM Range API to get the exact rendered text between the block's start and the break, mapping it back to a source offset only after confirming the block is plain text (a whitespace-normalized copy of the source must match the block's rendered `textContent` exactly). Anything reshaped by inline markup (bold, links, code, entities) fails that check and falls back to the existing proportional approximation, untouched.
- `extractPageBreaks()` gains an optional `exactBreaks` parameter, checked first per page — fully backward compatible (defaults to `undefined`). `runPagination()` registers the hook right after constructing the `Previewer` and threads the collected break-token map through.

## Verification
- [x] `npx tsc --noEmit`
- [x] `npm test` (525 tests, 19 covering `resolveExactBreakPos` directly plus `extractPageBreaks` integration)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Live-verified via CDP against the running app: a fresh 500-sentence single-paragraph repro produced 6 page breaks, all landing exactly at word boundaries (space or period immediately before each break) — the signature of a real Paged.js line-wrap cut, which a proportional guess landing there 6/6 times by chance would be essentially impossible.
- [x] Confirmed the actual Export-to-PDF pipeline (a separate Paged.js pass) is unaffected and paginates correctly.

## Test plan
- [ ] Open a document with a long paragraph spanning 2+ pages and confirm the in-editor divider lands at the same point as the real PDF/print preview.
- [ ] Confirm a paragraph containing bold/italic/links still shows a break (falls back to the proportional estimate) rather than nothing.