### PR TITLE
chore(release): bump to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   snapshot used to be deleted at the moment it was offered back, and the next one
   was over a second away and waiting on an edit that might never come, so a
   document recovered and then left untouched existed nowhere but in memory. A
-  crash or a forced close in that window lost it — the exact failure recovery
+  crash or a forced close in that window lost it: the exact failure recovery
   exists to prevent. Each draft is now written straight back, under the key of
   whichever window ends up holding it.
 
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dialogs no longer stretch to the width of the window** when they hold a long
   message. Their width is capped at a readable column, for every dialog rather
   than only the ones where it had been noticed.
-- Em dashes in labels and messages give way to plainer punctuation — a colon, a
+- Em dashes in labels and messages give way to plainer punctuation: a colon, a
   comma or parentheses. The window title keeps its dash, which is the
   conventional form there.
 
@@ -169,12 +169,12 @@ First public release.
 - **The page-setup block cannot inject CSS.** A margin value travels with the
   document and is interpolated into the printed page's `@page` rule, so it is
   validated as plain CSS lengths and nothing else. Without that, a document could
-  close the rule and append styles of its own — applied on open, since page
-  layout is measured when a file loads, not when it is printed.
+  close the rule and append styles of its own (applied on open, since page
+  layout is measured when a file loads, not when it is printed).
 - **Remote content is blocked on every attribute that fetches**, not just
   `<img src>`: `srcset`, `poster` and the legacy `background` attribute on any
   element, `href`/`xlink:href` on the SVG elements that load one, and any inline
-  `style` that references a remote URL — including through CSS escape sequences
+  `style` that references a remote URL, including through CSS escape sequences
   and `image-set()`, neither of which a pattern over `url()` tokens catches.
   Inline `data:` images are unaffected, in either setting.
 - **Exported HTML carries its own Content-Security-Policy.** A shared `.html`
@@ -212,7 +212,7 @@ First public release.
   both exports. Monoleaf does not emit them, and allowing tags it never produces
   only widens what an untrusted document can reach for. Images, math and tables
   are unaffected.
-- **Page margins accept plain CSS lengths only** — one to four values in `mm`,
+- **Page margins accept plain CSS lengths only:** one to four values in `mm`,
   `cm`, `in`, `pt` or `px`, or a bare `0`. Anything else in a document's page
   setup falls back to the default, because a margin travels with the file
   straight into the printed page's style rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Monoleaf are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-08-23
 
 ### Added
 
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   falls back to the previous best-effort estimate, which itself no longer
   collapses onto a single position when a paragraph spans more than two
   pages.
+- **Bold, italic, strikethrough, inline code, subscript and superscript no
+  longer stack extra markers when toggled twice with nothing typed in
+  between.** Clicking the same formatting button again on an empty
+  selection used to wrap the cursor in an ever-growing pile of markers
+  (`**` → `****` → `********`…) instead of clearing the empty pair.
 
 ## [1.1.0] - 2026-08-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monoleaf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monoleaf",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monoleaf",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A portable, WYSIWYG Markdown editor — one file, single source of truth.",
   "license": "MIT",
   "author": "vibingbiochemist <info@monoleaf.org>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "monoleaf"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "pdf-extract",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoleaf"
-version = "1.1.0"
+version = "1.2.0"
 description = "Monoleaf - a portable, single-file markdown editor"
 authors = ["vibingbiochemist <info@monoleaf.org>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Monoleaf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "org.monoleaf.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Bumps the version to `1.2.0` in `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.
- Converts `CHANGELOG.md`'s `## [Unreleased]` section into `## [1.2.0] - 2026-08-23`, covering everything merged since 1.1.0: bundled document fonts (#37), the print/pagination CSS scoping fix (#36), the in-editor page-break indicator's exact-offset fix (#40), and the inline-toggle empty-pair stacking fix (#39). Added the changelog entry for #39, which hadn't gotten one yet.
- Separately cleans up some leftover em-dash punctuation in the historical changelog entries (pre-existing, unrelated to this release's content — style-only, no behavior change).

## Not included
- **No tag is pushed by this PR.** Once merged, the actual release (`git tag v1.2.0 && git push public v1.2.0`, which triggers `release.yml` to build the Windows installer + Linux AppImage and draft a GitHub Release) is a separate, explicit step for later.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (532 passing)
- [x] `npm run lint`
- [x] `npm run format:check`