### PR TITLE
fix(tables): render page-break dividers inside multi-page tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Monoleaf are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Page breaks are no longer invisible inside a table that spans multiple
+  pages.** A table is rendered in the editor as one interactive grid, so a
+  page-break divider landing inside it had nowhere to draw — the divider now
+  renders as a row inside the table itself, at the same row the real
+  PDF/print output breaks on.
+
 ## [1.2.0] - 2026-08-23
 
 ### Added

--- a/src/pagination.test.ts
+++ b/src/pagination.test.ts
@@ -351,6 +351,136 @@ describe("resolveExactBreakPos", () => {
   });
 });
 
+describe("resolveExactBreakPos: table rows", () => {
+  // "Line 1<br>Line 2<br>Line 3" split across 3 text nodes by 2 real <br>
+  // elements — the shape a browser gives a rendered table cell with forced
+  // line breaks, matching the real repro that surfaced this (a cell with
+  // many <br>-separated lines, taller than a single printed page).
+  const ROW = "| short | Line 1<br>Line 2<br>Line 3 |\n";
+
+  function buildRow() {
+    const state = EditorState.create({ doc: ROW });
+    const tr = document.createElement("tr");
+    tr.setAttribute("data-srcline", "0");
+    tr.setAttribute("data-srcline-end", "1");
+    const td0 = document.createElement("td");
+    td0.textContent = "short";
+    const td1 = document.createElement("td");
+    td1.append(
+      document.createTextNode("Line 1"),
+      document.createElement("br"),
+      document.createTextNode("Line 2"),
+      document.createElement("br"),
+      document.createTextNode("Line 3"),
+    );
+    tr.append(td0, td1);
+    return { state, tr, td1 };
+  }
+
+  it("resolves a break inside a <br>-separated cell to the exact source character", () => {
+    const { state, td1 } = buildRow();
+    // The middle text node, 3 chars in: "Lin|e 2" — right after "Lin".
+    const middleTextNode = td1.childNodes[2];
+    const pos = resolveExactBreakPos(
+      { node: middleTextNode, offset: 3 },
+      state,
+    );
+    expect(pos).not.toBeNull();
+    // Must land exactly between the "n" and the "e" of the SECOND "Line 2",
+    // not the first "Line 1" or third "Line 3".
+    expect(state.doc.sliceString(pos! - 3, pos!)).toBe("Lin");
+    expect(state.doc.sliceString(pos!, pos! + 3)).toBe("e 2");
+  });
+
+  it("returns null for a break on inter-cell whitespace (no cell ancestor)", () => {
+    const { state, tr } = buildRow();
+    // A text node that's a direct child of <tr>, not inside any <td> — the
+    // inter-cell whitespace markdown-it's HTML string produces once parsed.
+    const whitespaceNode = document.createTextNode("\n");
+    tr.insertBefore(whitespaceNode, tr.firstChild);
+    expect(
+      resolveExactBreakPos({ node: whitespaceNode, offset: 0 }, state),
+    ).toBe(null);
+  });
+
+  it("returns null exactly at a cell boundary (start or end)", () => {
+    const { state, td1 } = buildRow();
+    const firstTextNode = td1.childNodes[0];
+    // Offset 0 of the cell's first text node = the cell's very start.
+    expect(
+      resolveExactBreakPos({ node: firstTextNode, offset: 0 }, state),
+    ).toBe(null);
+    const lastTextNode = td1.childNodes[4];
+    // End of the cell's last text node = the cell's very end.
+    expect(
+      resolveExactBreakPos(
+        { node: lastTextNode, offset: (lastTextNode.textContent ?? "").length },
+        state,
+      ),
+    ).toBe(null);
+  });
+
+  it("returns null for a break inside a cell containing an escaped pipe (that same cell, not just any cell in the row)", () => {
+    const state = EditorState.create({ doc: "| short | a\\|b<br>Line 2 |\n" });
+    const tr = document.createElement("tr");
+    tr.setAttribute("data-srcline", "0");
+    tr.setAttribute("data-srcline-end", "1");
+    const td0 = document.createElement("td");
+    td0.textContent = "short";
+    const td1 = document.createElement("td");
+    const textNode = document.createTextNode("Line 2");
+    td1.append(
+      document.createTextNode("a|b"),
+      document.createElement("br"),
+      textNode,
+    );
+    tr.append(td0, td1);
+    expect(resolveExactBreakPos({ node: textNode, offset: 2 }, state)).toBe(
+      null,
+    );
+  });
+
+  it("still resolves exactly when a DIFFERENT cell in the same row has an escaped pipe or rich formatting", () => {
+    const state = EditorState.create({
+      doc: "| a\\|b | Line 1<br>Line 2 |\n",
+    });
+    const tr = document.createElement("tr");
+    tr.setAttribute("data-srcline", "0");
+    tr.setAttribute("data-srcline-end", "1");
+    const td0 = document.createElement("td");
+    td0.textContent = "a|b";
+    const td1 = document.createElement("td");
+    const textNode = document.createTextNode("Line 2");
+    td1.append(
+      document.createTextNode("Line 1"),
+      document.createElement("br"),
+      textNode,
+    );
+    tr.append(td0, td1);
+    expect(
+      resolveExactBreakPos({ node: textNode, offset: 2 }, state),
+    ).not.toBeNull();
+  });
+
+  it("returns null for a break inside a cell reshaped by real markdown formatting", () => {
+    const state = EditorState.create({ doc: "| plain | **bo**ld |\n" });
+    const tr = document.createElement("tr");
+    tr.setAttribute("data-srcline", "0");
+    tr.setAttribute("data-srcline-end", "1");
+    const td0 = document.createElement("td");
+    td0.textContent = "plain";
+    const td1 = document.createElement("td");
+    const strong = document.createElement("strong");
+    strong.textContent = "bo";
+    const textNode = document.createTextNode("ld");
+    td1.append(strong, textNode);
+    tr.append(td0, td1);
+    expect(resolveExactBreakPos({ node: textNode, offset: 1 }, state)).toBe(
+      null,
+    );
+  });
+});
+
 describe("explicit page break directive", () => {
   it("becomes a forced-break div, and following content stays a block", () => {
     const html = renderDocumentHtml(

--- a/src/pagination.test.ts
+++ b/src/pagination.test.ts
@@ -6,6 +6,7 @@ import {
   buildPageBreakDecorations,
   extractPageBreaks,
   pageAt,
+  pageBreakPositions,
   pageBreaksField,
   resolveExactBreakPos,
   setPageBreaks,
@@ -43,6 +44,30 @@ describe("page break decorations", () => {
     const it2 = set.iter();
     expect(it2.value).not.toBeNull();
     expect(it2.from).toBe(15);
+  });
+});
+
+describe("pageBreakPositions", () => {
+  it("is empty when the field isn't present (pagination off)", () => {
+    const state = EditorState.create({ doc: "hello\n" });
+    expect(pageBreakPositions(state)).toEqual([]);
+  });
+
+  it("returns the dispatched breaks as plain {pos, page} data", () => {
+    const state = EditorState.create({
+      doc: "aaaa\nbbbb\ncccc\n",
+      extensions: pageBreaksField,
+    });
+    const withBreaks = state.update({
+      effects: setPageBreaks.of([
+        { pos: 5, page: 2 },
+        { pos: 10, page: 3 },
+      ]),
+    }).state;
+    expect(pageBreakPositions(withBreaks)).toEqual([
+      { pos: 5, page: 2 },
+      { pos: 10, page: 3 },
+    ]);
   });
 });
 

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -87,6 +87,23 @@ export const pageBreaksField = StateField.define<DecorationSet>({
   provide: (f) => EditorView.decorations.from(f),
 });
 
+/** The current page breaks as plain {pos, page} data, for consumers (like
+ * tablewidget.ts) that need the positions without depending on
+ * PageBreakWidget or decoration internals. [] when pagination is off (the
+ * field doesn't exist outside livePreviewExtensions). */
+export function pageBreakPositions(state: EditorState): PageBreak[] {
+  const deco = state.field(pageBreaksField, false);
+  if (deco === undefined) return [];
+  const result: PageBreak[] = [];
+  const it = deco.iter();
+  while (it.value !== null) {
+    const widget = (it.value.spec as { widget?: { page: number } }).widget;
+    if (widget !== undefined) result.push({ pos: it.from, page: widget.page });
+    it.next();
+  }
+  return result;
+}
+
 /** The stale, clone-inherited data-srcline of a continuation-only page — the
  * block it's continuing, identified by that block's own start line — or
  * null if the page isn't a pure continuation (no data-srcline at all). */

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -5,6 +5,8 @@ import {
   EditorView,
   WidgetType,
 } from "@codemirror/view";
+import { splitRowWithPositions } from "./table";
+import { cellDisplayTextWithMap } from "./tablecell";
 
 /**
  * Accurate in-editor page awareness. A background job (main.ts) runs the
@@ -150,6 +152,11 @@ export function resolveExactBreakPos(
     Math.min(startLine + 1, state.doc.lines),
   ).from;
   const blockTo = state.doc.line(Math.min(endLine, state.doc.lines)).to;
+
+  if (blockEl.tagName === "TR") {
+    return resolveTableCellBreakPos(token, state, blockEl, blockFrom, blockTo);
+  }
+
   const sourceText = state.doc.sliceString(blockFrom, blockTo);
 
   // Collapse whitespace runs to a single space, the same way CommonMark
@@ -186,6 +193,64 @@ export function resolveExactBreakPos(
       ? toOriginal[renderedOffset]
       : sourceText.length;
   return blockFrom + originalIndex;
+}
+
+/**
+ * resolveExactBreakPos's table-row path. A <tr>'s own textContent can't be
+ * used the way a paragraph's can: markdown-it's HTML output puts a literal
+ * newline between sibling <td>s, which a browser parses as real text nodes
+ * between them — no per-cell concatenation without separators can ever
+ * reproduce that, so matching at the row level would always fail. Instead,
+ * find the <td>/<th> ancestor of the break token's node and match just that
+ * ONE cell's rendered text against its own raw source span — a single cell
+ * has no injected newlines inside it, and precision degrades per cell
+ * rather than per row (a plain cell can resolve exactly even if a sibling
+ * cell in the same row has rich markdown formatting).
+ */
+function resolveTableCellBreakPos(
+  token: BreakToken,
+  state: EditorState,
+  rowEl: Element,
+  rowFrom: number,
+  rowTo: number,
+): number | null {
+  const startEl =
+    token.node.nodeType === Node.ELEMENT_NODE
+      ? (token.node as Element)
+      : token.node.parentElement;
+  const cellEl = startEl?.closest("td, th");
+  // No cell ancestor (the break landed on inter-cell whitespace) or it
+  // belongs to some OTHER row entirely: nothing to anchor to here.
+  if (cellEl == null || !rowEl.contains(cellEl)) return null;
+
+  const cells = Array.from((rowEl as HTMLTableRowElement).cells ?? []);
+  const colIndex = cells.indexOf(cellEl as HTMLTableCellElement);
+  if (colIndex === -1) return null;
+
+  const rowText = state.doc.sliceString(rowFrom, rowTo);
+  const span = splitRowWithPositions(rowText)[colIndex];
+  // An escaped "\|" would need reconciling two different index spaces
+  // (source vs. unescaped model text) for one rare case — bail instead.
+  if (span === undefined || span.raw.includes("\\|")) return null;
+
+  const { text: expected, toOriginal } = cellDisplayTextWithMap(span.raw);
+  if (expected !== cellEl.textContent) return null; // formatted — bail
+
+  const range = document.createRange();
+  range.setStart(cellEl, 0);
+  if (token.node.nodeType === Node.TEXT_NODE) {
+    const len = token.node.textContent?.length ?? 0;
+    range.setEnd(token.node, Math.min(token.offset, len));
+  } else {
+    range.setEnd(token.node, 0);
+  }
+  const renderedOffset = range.toString().length;
+  // Exactly at a cell boundary isn't a mid-cell split — the row-level
+  // fallback owns boundary cases uniformly (extractPageBreaks' existing
+  // strict-inequality convention for "inside" a table's range).
+  if (renderedOffset <= 0 || renderedOffset >= expected.length) return null;
+
+  return rowFrom + span.start + toOriginal[renderedOffset];
 }
 
 /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,6 +8,11 @@
   --accent: light-dark(#e8a33d, #e8a33d);
   --accent-soft: light-dark(rgba(232, 163, 61, 0.16), rgba(232, 163, 61, 0.22));
   --bg: light-dark(#f6f6f4, #191b1e);
+  /* The live view's gray canvas behind the white page card — kept as its
+     own variable (not --bg, the general app-chrome background) so the
+     page-break "gap" dividers can match it exactly rather than showing a
+     slightly-off grey of their own. */
+  --canvas-bg: light-dark(#d7d7d4, #141413);
   --panel: light-dark(#fbfbfa, #23252a);
   --border: light-dark(#e4e3df, #383b42);
   --text: light-dark(#20201e, #f5f1e8);
@@ -653,7 +658,7 @@ html.theme-dark .brand-dark {
 .ml-table-pagebreak-gap-space {
   height: 30px;
   margin: 0 -30px; /* bleeds further, past the card border/shadow — same as .cm-page-gap-space */
-  background: var(--bg);
+  background: var(--canvas-bg);
 }
 
 .ml-table-pagebreak-gap-top {
@@ -1066,7 +1071,7 @@ html.theme-dark .brand-dark {
 .cm-page-gap-space {
   height: 30px;
   margin: 0 -30px; /* beyond the card border and shadow */
-  background: var(--bg);
+  background: var(--canvas-bg);
   box-shadow:
     inset 0 7px 7px -7px rgba(0, 0, 0, 0.28),
     inset 0 -7px 7px -7px rgba(0, 0, 0, 0.28);
@@ -1125,7 +1130,7 @@ html.theme-dark .brand-dark {
    sheet. The #editor.live prefix outranks CodeMirror's base .cm-content
    (which is flex-grow:2 and would otherwise fill the scroller). */
 #editor.live .cm-scroller {
-  background: light-dark(#d7d7d4, #141413);
+  background: var(--canvas-bg);
   padding: 26px 16px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -623,24 +623,53 @@ html.theme-dark .brand-dark {
 
 /* A page break landing inside a multi-page table: the table itself is one
    opaque replaced widget (see tablewidget.ts), so the standalone
-   .cm-page-gap divider — designed to bleed across the page card's own
-   padding — can't render here. This is the in-table equivalent: a plain
-   dashed rule scoped to the row, not the page. */
+   .cm-page-gap divider can't render here. table-row/table-cell layout
+   ignores margins, so a <td> can't bleed past the table's own width the way
+   .cm-page-gap bleeds past the page card's padding — instead the TD just
+   reserves the right VERTICAL space in the table's normal flow (matching
+   .cm-page-gap's own 58/30/58 total height), and .ml-table-pagebreak-bleed
+   escapes it via absolute positioning, bleeding left/right by the SAME
+   amount .cm-page-gap does, without widening the table itself. The result
+   looks like the same page break everywhere in the document, table or not. */
 .ml-table-pagebreak td {
-  border-left: none;
-  border-right: none;
-  border-top: 1px dashed light-dark(#c9c8c4, #4a4a46);
-  border-bottom: 1px dashed light-dark(#c9c8c4, #4a4a46);
-  padding: 4px 0;
-  text-align: center;
+  position: relative;
+  border: none;
+  padding: 0;
+  height: 146px; /* 58 + 30 + 58 — the visible content moved to the bleed */
+}
+
+.ml-table-pagebreak-bleed {
+  position: absolute;
+  inset: 0 -72px; /* same horizontal bleed as .cm-page-gap's margin */
+}
+
+.ml-table-pagebreak-gap-bottom {
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ml-table-pagebreak-gap-space {
+  height: 30px;
+  margin: 0 -30px; /* bleeds further, past the card border/shadow — same as .cm-page-gap-space */
   background: var(--bg);
 }
 
-.ml-table-pagebreak-num {
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
+.ml-table-pagebreak-gap-top {
+  height: 58px;
+}
+
+/* A page break landing INSIDE a single cell's own content — a cell tall
+   enough to need one of its own, e.g. a run of forced <br> line breaks.
+   Sits normally in the cell's text flow (keeping whatever vertical position
+   that gives it); position: relative makes it the anchor for
+   .ml-table-pagebreak-bleed's escape to the page card's edge. */
+.ml-table-pagebreak-inline {
+  display: block;
+  position: relative;
+  height: 146px;
+  user-select: none;
 }
 
 .ml-table-bar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -621,6 +621,28 @@ html.theme-dark .brand-dark {
   background: light-dark(rgba(232, 163, 61, 0.08), rgba(232, 163, 61, 0.12));
 }
 
+/* A page break landing inside a multi-page table: the table itself is one
+   opaque replaced widget (see tablewidget.ts), so the standalone
+   .cm-page-gap divider — designed to bleed across the page card's own
+   padding — can't render here. This is the in-table equivalent: a plain
+   dashed rule scoped to the row, not the page. */
+.ml-table-pagebreak td {
+  border-left: none;
+  border-right: none;
+  border-top: 1px dashed light-dark(#c9c8c4, #4a4a46);
+  border-bottom: 1px dashed light-dark(#c9c8c4, #4a4a46);
+  padding: 4px 0;
+  text-align: center;
+  background: var(--bg);
+}
+
+.ml-table-pagebreak-num {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
 .ml-table-bar {
   position: absolute;
   top: -30px;

--- a/src/table.ts
+++ b/src/table.ts
@@ -37,6 +37,68 @@ function splitRow(line: string): string[] {
   return cells;
 }
 
+export interface RowCellSpan {
+  /** The exact line.slice(start, end) — deliberately NOT unescaped (unlike
+   * splitRow's cells), so raw.length === end - start always holds. Callers
+   * needing the model's unescaped text still go through splitRow/TableModel. */
+  raw: string;
+  start: number;
+  end: number;
+}
+
+const isWs = (ch: string | undefined) => ch !== undefined && /\s/.test(ch);
+
+/** Trim ws from [start, end) within line, returning the trimmed span. */
+function trimSpan(line: string, start: number, end: number): RowCellSpan {
+  let s = start;
+  let e = end;
+  while (s < e && isWs(line[s])) s++;
+  while (e > s && isWs(line[e - 1])) e--;
+  return { raw: line.slice(s, e), start: s, end: e };
+}
+
+/**
+ * Position-aware sibling of splitRow: same escape-aware pipe-boundary
+ * scanning (leading/trailing pipe stripped, \| doesn't end a cell, each
+ * cell trimmed), but reports each cell's [start, end) offset within `line`
+ * instead of returning an unescaped model string. Used to map an absolute
+ * editor position (e.g. a page-break) back to "which cell, what offset" —
+ * see resolveExactBreakPos (pagination.ts) and buildDecorations
+ * (tablewidget.ts).
+ */
+export function splitRowWithPositions(line: string): RowCellSpan[] {
+  const cells: RowCellSpan[] = [];
+
+  // Mirror splitRow's line.trim().replace(/^\|/, "").replace(/\|$/, ""), but
+  // track positions in the ORIGINAL string instead of a separate copy.
+  let i = 0;
+  const n = line.length;
+  while (i < n && isWs(line[i])) i++;
+  let end = n;
+  while (end > i && isWs(line[end - 1])) end--;
+  if (i < end && line[i] === "|") i++;
+  if (end > i && line[end - 1] === "|") end--;
+
+  let cellStart = i;
+  let escaped = false;
+  for (let p = i; p < end; p++) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (line[p] === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (line[p] === "|") {
+      cells.push(trimSpan(line, cellStart, p));
+      cellStart = p + 1;
+    }
+  }
+  cells.push(trimSpan(line, cellStart, end));
+  return cells;
+}
+
 function parseAlign(cell: string): ColAlign | null {
   const t = cell.trim();
   if (!/^:?-+:?$/.test(t)) return null;

--- a/src/table.ts
+++ b/src/table.ts
@@ -91,7 +91,13 @@ export function splitRowWithPositions(line: string): RowCellSpan[] {
       continue;
     }
     if (line[p] === "|") {
-      cells.push(trimSpan(line, cellStart, p));
+      // CodeQL flags this as js/incomplete-sanitization: the `escaped`
+      // backslash-tracking above superficially resembles an escaper that
+      // "misses" backslashes, but this function isn't sanitizing anything —
+      // it's a boundary finder that deliberately returns exact, untouched
+      // substrings (raw.length === end - start always holds; see the
+      // doc comment above), so escaping was never the goal here.
+      cells.push(trimSpan(line, cellStart, p)); // lgtm[js/incomplete-sanitization]
       cellStart = p + 1;
     }
   }

--- a/src/tablecell.ts
+++ b/src/tablecell.ts
@@ -259,5 +259,51 @@ export function cellDisplayHtml(raw: string): string {
  * `<br>` contributes nothing, matching how `textContent` sees a real <br>.
  */
 export function cellDisplayText(raw: string): string {
-  return decodeEntities(raw.replace(TAG_RE, ""));
+  return cellDisplayTextWithMap(raw).text;
+}
+
+/**
+ * Same transformation as cellDisplayText, but also returns a rendered-index
+ * -> source-index map (one entry per emitted character), for mapping an
+ * exact rendered offset (e.g. a page-break position, via the DOM Range API)
+ * back to where it falls in the cell's raw markdown source. Iterates by
+ * UTF-16 index, matching how Range.toString().length counts characters —
+ * not by code point — so surrogate pairs and multi-digit numeric character
+ * references stay aligned with what the DOM actually measures.
+ */
+export function cellDisplayTextWithMap(raw: string): {
+  text: string;
+  toOriginal: number[];
+} {
+  let text = "";
+  const toOriginal: number[] = [];
+  const n = raw.length;
+  let i = 0;
+  while (i < n) {
+    TAG_RE.lastIndex = i;
+    const tag = TAG_RE.exec(raw);
+    if (tag !== null && tag.index === i) {
+      i += tag[0].length; // zero-width: a real <br> contributes no text
+      continue;
+    }
+    ENTITY_RE.lastIndex = i;
+    const entity = ENTITY_RE.exec(raw);
+    if (entity !== null && entity.index === i) {
+      const body = entity[1];
+      const decoded = body.startsWith("#")
+        ? (codePointText(body) ?? entity[0])
+        : (NAMED_ENTITIES[body] ?? entity[0]);
+      // An unresolved entity decodes to its own literal text (matching
+      // decodeEntities), so every emitted char maps back to the entity's
+      // start — imprecise for that rare case, never unsafe.
+      for (let k = 0; k < decoded.length; k++) toOriginal.push(i);
+      text += decoded;
+      i += entity[0].length;
+      continue;
+    }
+    toOriginal.push(i);
+    text += raw[i];
+    i++;
+  }
+  return { text, toOriginal };
 }

--- a/src/tablewidget.test.ts
+++ b/src/tablewidget.test.ts
@@ -254,7 +254,7 @@ describe("page breaks landing inside a table", () => {
 
     const dividers = view.dom.querySelectorAll("tr.ml-table-pagebreak");
     expect(dividers.length).toBe(1);
-    expect(dividers[0].textContent).toContain("Page 1");
+    expect(dividers[0].querySelector(".cm-page-num")?.textContent).toBe("1");
     // It sits directly before the row it announces.
     const nextRow = dividers[0].nextElementSibling;
     expect(nextRow?.textContent).toContain("r1c1");
@@ -292,6 +292,117 @@ describe("page breaks landing inside a table", () => {
   it("existing tables with no pagination field render exactly as before", () => {
     const view = mount(ROWS);
     expect(view.dom.querySelectorAll("tr.ml-table-pagebreak").length).toBe(0);
+    view.destroy();
+  });
+});
+
+// A single cell taller than a page (many forced <br> line breaks) — the
+// real case that surfaced this: a row-level divider has no row boundary to
+// anchor to mid-cell, so the divider has to render INSIDE the cell itself.
+describe("page breaks landing inside a single tall cell", () => {
+  const TALL = `| short | tall |
+| --- | --- |
+| a | Line 1<br>Line 2<br>Line 3 |
+`;
+
+  function tallCellDataRowLine(view: EditorView) {
+    return view.state.doc.line(3); // "| a | Line 1<br>Line 2<br>Line 3 |"
+  }
+
+  it("renders exactly one inline divider at the right split point", () => {
+    const view = mount(TALL, [pageBreaksField]);
+    const line = tallCellDataRowLine(view);
+    // Right after "Line 1<br>Line 2" — i.e. between the second and third
+    // forced line, inside the tall cell's own raw text.
+    const pos = line.from + line.text.indexOf("Line 2<br>") + "Line 2".length;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 3 }]) });
+
+    const dividers = view.dom.querySelectorAll(".ml-table-pagebreak-inline");
+    expect(dividers.length).toBe(1);
+    expect(dividers[0].querySelector(".cm-page-num")?.textContent).toBe("2");
+    // No row-level divider was ALSO added for this break.
+    expect(view.dom.querySelectorAll("tr.ml-table-pagebreak").length).toBe(0);
+
+    const cell = dividers[0].closest("[data-row]") as HTMLElement;
+    expect(cell.dataset.row).toBe("0");
+    expect(cell.dataset.col).toBe("1");
+    // Splits the cell's own rendered content around the divider.
+    expect(cell.textContent).toContain("Line 1");
+    expect(cell.textContent).toContain("Line 2");
+    expect(cell.textContent).toContain("Line 3");
+    view.destroy();
+  });
+
+  it("survives a focus+blur cycle on the split cell with no edit", () => {
+    const view = mount(TALL, [pageBreaksField]);
+    const line = tallCellDataRowLine(view);
+    const pos = line.from + line.text.indexOf("Line 2<br>") + "Line 2".length;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 3 }]) });
+
+    const cell = view.dom.querySelector<HTMLElement>(
+      '[data-row="0"][data-col="1"]',
+    )!;
+    cell.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    cell.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    expect(cell.querySelectorAll(".ml-table-pagebreak-inline").length).toBe(1);
+    // The document itself was never touched.
+    expect(view.state.doc.toString()).toContain("Line 1<br>Line 2<br>Line 3");
+    view.destroy();
+  });
+
+  it("shows the raw source (no divider) while the split cell is being edited", () => {
+    const view = mount(TALL, [pageBreaksField]);
+    const line = tallCellDataRowLine(view);
+    const pos = line.from + line.text.indexOf("Line 2<br>") + "Line 2".length;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 3 }]) });
+
+    const cell = view.dom.querySelector<HTMLElement>(
+      '[data-row="0"][data-col="1"]',
+    )!;
+    cell.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    expect(cell.querySelector(".ml-table-pagebreak-inline")).toBeNull();
+    // Exact equality (not just "contains") proves the divider's own label
+    // is never part of what an edit session reads as the cell's value.
+    expect(cell.textContent).toBe("Line 1<br>Line 2<br>Line 3");
+    view.destroy();
+  });
+
+  it("still commits an edit to the split cell correctly", () => {
+    const view = mount(TALL, [pageBreaksField]);
+    const line = tallCellDataRowLine(view);
+    const pos = line.from + line.text.indexOf("Line 2<br>") + "Line 2".length;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 3 }]) });
+
+    const cell = view.dom.querySelector<HTMLElement>(
+      '[data-row="0"][data-col="1"]',
+    )!;
+    cell.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    cell.textContent = "Line 1<br>Line 2<br>Line 3<br>Line 4";
+    cell.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    // Exact equality on the committed line (not just "contains") proves no
+    // divider label text leaked into the saved markdown.
+    expect(view.state.doc.line(3).text).toBe(
+      "| a | Line 1<br>Line 2<br>Line 3<br>Line 4 |",
+    );
+    view.destroy();
+  });
+
+  it("falls back to a row-level divider when the column can't be pinned down (escaped pipe)", () => {
+    const ESCAPED = `| short | tall |
+| --- | --- |
+| a | x\\|y<br>Line 2<br>Line 3 |
+`;
+    const view = mount(ESCAPED, [pageBreaksField]);
+    const line = view.state.doc.line(3);
+    const pos = line.from + line.text.indexOf("Line 2<br>") + "Line 2".length;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 3 }]) });
+
+    expect(view.dom.querySelectorAll(".ml-table-pagebreak-inline").length).toBe(
+      0,
+    );
+    expect(view.dom.querySelectorAll("tr.ml-table-pagebreak").length).toBe(1);
     view.destroy();
   });
 });

--- a/src/tablewidget.test.ts
+++ b/src/tablewidget.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { EditorState } from "@codemirror/state";
+import { EditorState, Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { ensureSyntaxTree } from "@codemirror/language";
 import { markdownForMode } from "./portability";
+import { pageBreaksField, setPageBreaks } from "./pagination";
 import { tableExtensions } from "./tablewidget";
 
 // The reported document: <br> in the header, &nbsp; indentation in a sub-row.
@@ -13,12 +14,16 @@ const DOC = `| | Sample A<br>(n=12) |
 | &nbsp;&nbsp;Item one | 5 (4%) |
 `;
 
-function mount(doc: string): EditorView {
+function mount(doc: string, extraExtensions: Extension[] = []): EditorView {
   const parent = document.createElement("div");
   document.body.appendChild(parent);
   const state = EditorState.create({
     doc,
-    extensions: [markdownForMode("enhanced"), tableExtensions()],
+    extensions: [
+      markdownForMode("enhanced"),
+      tableExtensions(),
+      ...extraExtensions,
+    ],
   });
   ensureSyntaxTree(state, doc.length, 5000);
   const view = new EditorView({ state, parent });
@@ -224,6 +229,69 @@ describe("plain tables are unaffected", () => {
     cell.textContent = "0.9";
     cell.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
     expect(view.state.doc.toString()).toContain("| 0.9 |");
+    view.destroy();
+  });
+});
+
+// A table replaces its whole source range with one opaque widget (see
+// buildDecorations), so a page-break landing inside it can't render via the
+// normal standalone .cm-page-gap mechanism — extractPageBreaks computes a
+// perfectly good position, but CodeMirror has nowhere to paint it. The
+// table widget must render its own internal divider instead.
+describe("page breaks landing inside a table", () => {
+  const ROWS = `| h1 | h2 |
+| --- | --- |
+| r0c1 | r0c2 |
+| r1c1 | r1c2 |
+| r2c1 | r2c2 |
+`;
+
+  it("renders an internal divider row at the break's row", () => {
+    const view = mount(ROWS, [pageBreaksField]);
+    // Line 4 (1-based) is "| r1c1 | r1c2 |" — the second data row.
+    const pos = view.state.doc.line(4).from;
+    view.dispatch({ effects: setPageBreaks.of([{ pos, page: 2 }]) });
+
+    const dividers = view.dom.querySelectorAll("tr.ml-table-pagebreak");
+    expect(dividers.length).toBe(1);
+    expect(dividers[0].textContent).toContain("Page 1");
+    // It sits directly before the row it announces.
+    const nextRow = dividers[0].nextElementSibling;
+    expect(nextRow?.textContent).toContain("r1c1");
+    view.destroy();
+  });
+
+  it("adds no internal divider for a break at or before the table's start", () => {
+    const view = mount(ROWS, [pageBreaksField]);
+    view.dispatch({
+      effects: setPageBreaks.of([{ pos: 0, page: 2 }]),
+    });
+    expect(view.dom.querySelectorAll("tr.ml-table-pagebreak").length).toBe(0);
+    view.destroy();
+  });
+
+  it("moves the divider when the breaks are recomputed (exercises eq())", () => {
+    const view = mount(ROWS, [pageBreaksField]);
+    const firstDataRow = view.state.doc.line(3).from; // "| r0c1 | r0c2 |"
+    view.dispatch({
+      effects: setPageBreaks.of([{ pos: firstDataRow, page: 2 }]),
+    });
+    let dividers = view.dom.querySelectorAll("tr.ml-table-pagebreak");
+    expect(dividers[0].nextElementSibling?.textContent).toContain("r0c1");
+
+    const thirdDataRow = view.state.doc.line(5).from; // "| r2c1 | r2c2 |"
+    view.dispatch({
+      effects: setPageBreaks.of([{ pos: thirdDataRow, page: 2 }]),
+    });
+    dividers = view.dom.querySelectorAll("tr.ml-table-pagebreak");
+    expect(dividers.length).toBe(1);
+    expect(dividers[0].nextElementSibling?.textContent).toContain("r2c1");
+    view.destroy();
+  });
+
+  it("existing tables with no pagination field render exactly as before", () => {
+    const view = mount(ROWS);
+    expect(view.dom.querySelectorAll("tr.ml-table-pagebreak").length).toBe(0);
     view.destroy();
   });
 });

--- a/src/tablewidget.ts
+++ b/src/tablewidget.ts
@@ -16,6 +16,7 @@ import {
   WidgetType,
 } from "@codemirror/view";
 import { MenuItem } from "./contextmenu";
+import { pageBreakPositions, setPageBreaks } from "./pagination";
 import { cellDisplayHtml, cellHasRichContent } from "./tablecell";
 import {
   ColAlign,
@@ -46,19 +47,33 @@ let pendingFocus: { from: number; row: number; col: number } | null = null;
 // Last focused cell, for the toolbar operations.
 let activeCell: { row: number; col: number } = { row: -1, col: 0 };
 
+export interface TableDivider {
+  /** 0-based index into model.rows; the divider renders just before it. */
+  row: number;
+  page: number;
+}
+
 class TableWidget extends WidgetType {
   constructor(
     readonly source: string,
     readonly from: number,
     readonly model: TableModel,
+    readonly dividers: TableDivider[],
   ) {
     super();
   }
   eq(other: TableWidget) {
-    return other.source === this.source;
+    return (
+      other.source === this.source &&
+      other.dividers.length === this.dividers.length &&
+      other.dividers.every(
+        (d, i) =>
+          d.row === this.dividers[i].row && d.page === this.dividers[i].page,
+      )
+    );
   }
   get estimatedHeight() {
-    return (this.model.rows.length + 2) * 38;
+    return (this.model.rows.length + 2 + this.dividers.length) * 38;
   }
   ignoreEvent() {
     return true;
@@ -68,17 +83,44 @@ class TableWidget extends WidgetType {
   }
 }
 
+/** A GFM table row is always exactly one physical source line (confirmed via
+ * the data-srcline the pagination measurement pass stamps on every <tr>), so
+ * a break's line number maps directly to a row index — offset by the
+ * header + delimiter lines every table starts with. */
+function dividerRowIndex(
+  state: EditorState,
+  tableFrom: number,
+  pos: number,
+): number {
+  const tableStartLine = state.doc.lineAt(tableFrom).number;
+  const breakLine = state.doc.lineAt(pos).number;
+  return breakLine - tableStartLine - 2;
+}
+
 function buildDecorations(state: EditorState): DecorationSet {
   const decos: ReturnType<Decoration["range"]>[] = [];
+  const breaks = pageBreakPositions(state);
   syntaxTree(state).iterate({
     enter: (node) => {
       if (node.name !== "Table") return;
       const source = state.sliceDoc(node.from, node.to);
       const model = parseTableText(source);
       if (model === null) return;
+      // A break at or before the table's own start already renders fine via
+      // the normal pageBreaksField mechanism (that position sits outside
+      // this replaced range); only breaks landing strictly inside need to be
+      // handled here, since CodeMirror can't paint anything inside a
+      // Decoration.replace span.
+      const dividers = breaks
+        .filter((b) => b.pos > node.from && b.pos < node.to)
+        .map((b) => ({
+          row: dividerRowIndex(state, node.from, b.pos),
+          page: b.page,
+        }))
+        .filter((d) => d.row >= 0 && d.row < model.rows.length);
       decos.push(
         Decoration.replace({
-          widget: new TableWidget(source, node.from, model),
+          widget: new TableWidget(source, node.from, model, dividers),
           block: true,
         }).range(node.from, node.to),
       );
@@ -91,7 +133,10 @@ function buildDecorations(state: EditorState): DecorationSet {
 export const tableField = StateField.define<DecorationSet>({
   create: buildDecorations,
   update(deco, tr) {
-    if (tr.docChanged || tr.effects.some((e) => e.is(refreshTables))) {
+    if (
+      tr.docChanged ||
+      tr.effects.some((e) => e.is(refreshTables) || e.is(setPageBreaks))
+    ) {
       return buildDecorations(tr.state);
     }
     return deco.map(tr.changes);
@@ -207,6 +252,22 @@ function revealCellSource(cell: HTMLElement) {
   }
 }
 
+/** A page-break divider row, spanning every column — the in-table
+ * equivalent of the standalone .cm-page-gap divider, which can't render here
+ * since the whole table sits inside one replaced decoration range. */
+function buildTablePageBreakRow(page: number, cols: number): HTMLElement {
+  const tr = document.createElement("tr");
+  tr.className = "ml-table-pagebreak";
+  const td = document.createElement("td");
+  td.colSpan = cols;
+  const label = document.createElement("span");
+  label.className = "ml-table-pagebreak-num";
+  label.textContent = `Page ${page - 1}`;
+  td.appendChild(label);
+  tr.appendChild(td);
+  return tr;
+}
+
 function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
   const model = widget.model;
   const wrap = document.createElement("div");
@@ -306,7 +367,11 @@ function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
   thead.appendChild(hr);
   table.appendChild(thead);
   const tbody = document.createElement("tbody");
+  const dividerBeforeRow = new Map(widget.dividers.map((d) => [d.row, d.page]));
   model.rows.forEach((cells, r) => {
+    const page = dividerBeforeRow.get(r);
+    if (page !== undefined)
+      tbody.appendChild(buildTablePageBreakRow(page, model.header.length));
     const tr = document.createElement("tr");
     cells.forEach((text, c) =>
       tr.appendChild(mkCell("td", r, c, text, model.aligns[c])),

--- a/src/tablewidget.ts
+++ b/src/tablewidget.ts
@@ -330,7 +330,16 @@ function showCell(cell: HTMLElement, raw: string, splits?: CellSplit[]) {
       prev = s.offset;
     }
     html += cellDisplayHtml(raw.slice(prev));
-    cell.innerHTML = html;
+    // CodeQL flags this as js/xss-through-dom: it can't see that every
+    // segment already went through cellDisplayHtml (escapes everything
+    // except an allowlisted, attribute-free tag set — see tablecell.ts's
+    // own safety comment) and buildInlinePageBreakHtml (interpolates only a
+    // `number`, Paged.js's own page count) — the same guarantee the
+    // pre-existing single-segment branch below already relies on. Even if
+    // that reasoning were somehow wrong, the app's CSP (script-src 'self',
+    // no unsafe-inline — src-tauri/tauri.conf.json) blocks inline script
+    // execution regardless of how it reached the DOM.
+    cell.innerHTML = html; // lgtm[js/xss-through-dom]
   } else if (cellHasRichContent(raw)) {
     cell.innerHTML = cellDisplayHtml(raw);
   } else {

--- a/src/tablewidget.ts
+++ b/src/tablewidget.ts
@@ -16,7 +16,7 @@ import {
   WidgetType,
 } from "@codemirror/view";
 import { MenuItem } from "./contextmenu";
-import { pageBreakPositions, setPageBreaks } from "./pagination";
+import { PageBreak, pageBreakPositions, setPageBreaks } from "./pagination";
 import { cellDisplayHtml, cellHasRichContent } from "./tablecell";
 import {
   ColAlign,
@@ -29,6 +29,7 @@ import {
   serializeTable,
   setAlign,
   setCell,
+  splitRowWithPositions,
   TableModel,
 } from "./table";
 
@@ -48,9 +49,15 @@ let pendingFocus: { from: number; row: number; col: number } | null = null;
 let activeCell: { row: number; col: number } = { row: -1, col: 0 };
 
 export interface TableDivider {
-  /** 0-based index into model.rows; the divider renders just before it. */
+  /** 0-based index into model.rows. */
   row: number;
   page: number;
+  /** When set, this divider renders INSIDE cell (row, splitCol) at
+   * splitOffset (an index into that cell's own raw text) instead of as a
+   * row before the whole row — for a single cell tall enough to need a
+   * page break of its own. */
+  splitCol?: number;
+  splitOffset?: number;
 }
 
 class TableWidget extends WidgetType {
@@ -66,14 +73,28 @@ class TableWidget extends WidgetType {
     return (
       other.source === this.source &&
       other.dividers.length === this.dividers.length &&
-      other.dividers.every(
-        (d, i) =>
-          d.row === this.dividers[i].row && d.page === this.dividers[i].page,
-      )
+      other.dividers.every((d, i) => {
+        const mine = this.dividers[i];
+        return (
+          d.row === mine.row &&
+          d.page === mine.page &&
+          d.splitCol === mine.splitCol &&
+          d.splitOffset === mine.splitOffset
+        );
+      })
     );
   }
   get estimatedHeight() {
-    return (this.model.rows.length + 2 + this.dividers.length) * 38;
+    // A "before whole row" divider adds a full extra row; a mid-cell split
+    // doesn't add a row but still adds its own ~146px (58+30+58, matching
+    // .cm-page-gap's proportions) within the existing one.
+    const rowDividers = this.dividers.filter(
+      (d) => d.splitCol === undefined,
+    ).length;
+    const inlineDividers = this.dividers.length - rowDividers;
+    return (
+      (this.model.rows.length + 2 + rowDividers) * 38 + inlineDividers * 146
+    );
   }
   ignoreEvent() {
     return true;
@@ -97,6 +118,43 @@ function dividerRowIndex(
   return breakLine - tableStartLine - 2;
 }
 
+/** Where a break landing inside a table should render: a mid-cell split
+ * (the common case for one cell tall enough to need a page break of its
+ * own) when the exact cell/offset can be safely determined, otherwise a
+ * divider before the whole row — the row-boundary case PR #42 already
+ * handled. Bails to the row-level form rather than guessing whenever the
+ * cell can't be pinned down exactly (escaped "\|", out-of-range column),
+ * same "exact when safe, approximate otherwise" posture as
+ * resolveExactBreakPos itself. */
+function resolveTableDivider(
+  state: EditorState,
+  tableFrom: number,
+  model: TableModel,
+  b: PageBreak,
+): TableDivider | null {
+  const row = dividerRowIndex(state, tableFrom, b.pos);
+  if (row < 0 || row >= model.rows.length) return null;
+
+  const line = state.doc.lineAt(b.pos);
+  const spans = splitRowWithPositions(line.text);
+  const colIndex = spans.findIndex(
+    (s) => b.pos > line.from + s.start && b.pos < line.from + s.end,
+  );
+  if (
+    colIndex === -1 ||
+    colIndex >= model.rows[row].length ||
+    spans[colIndex].raw.includes("\\|")
+  ) {
+    return { row, page: b.page }; // divider before the whole row
+  }
+  return {
+    row,
+    page: b.page,
+    splitCol: colIndex,
+    splitOffset: b.pos - (line.from + spans[colIndex].start),
+  };
+}
+
 function buildDecorations(state: EditorState): DecorationSet {
   const decos: ReturnType<Decoration["range"]>[] = [];
   const breaks = pageBreakPositions(state);
@@ -113,11 +171,8 @@ function buildDecorations(state: EditorState): DecorationSet {
       // Decoration.replace span.
       const dividers = breaks
         .filter((b) => b.pos > node.from && b.pos < node.to)
-        .map((b) => ({
-          row: dividerRowIndex(state, node.from, b.pos),
-          page: b.page,
-        }))
-        .filter((d) => d.row >= 0 && d.row < model.rows.length);
+        .map((b) => resolveTableDivider(state, node.from, model, b))
+        .filter((d): d is TableDivider => d !== null);
       decos.push(
         Decoration.replace({
           widget: new TableWidget(source, node.from, model, dividers),
@@ -220,17 +275,67 @@ function focusCell(view: EditorView, from: number, row: number, col: number) {
   });
 }
 
+interface CellSplit {
+  /** Index into the cell's own raw text where the divider is inserted. */
+  offset: number;
+  page: number;
+}
+
+/** A page-break divider meant to sit INSIDE a cell's own rendered content —
+ * the in-table equivalent of the standalone .cm-page-gap divider, used when
+ * a single cell is itself too tall to fit on one page. Its own label text
+ * DOES contribute to `.textContent`, which is exactly why revealCellSource
+ * below can't rely on a plain string-equality check to know whether a cell
+ * needs revealing. */
+function buildInlinePageBreakHtml(page: number): string {
+  // Same bottom-margin/gap/top-margin structure as the standalone
+  // .cm-page-gap divider (pagination.ts's PageBreakWidget), including its
+  // horizontal bleed: .ml-table-pagebreak-inline sits normally in the
+  // cell's own text flow (so it keeps whatever vertical position that gives
+  // it), and .ml-table-pagebreak-bleed — an absolutely positioned child —
+  // escapes it horizontally to reach the page card's edge the same way
+  // .cm-page-gap does, without affecting the cell's own layout.
+  return (
+    `<div class="ml-table-pagebreak-inline" contenteditable="false">` +
+    `<div class="ml-table-pagebreak-bleed">` +
+    `<div class="ml-table-pagebreak-gap-bottom">` +
+    `<span class="cm-page-num">${page - 1}</span></div>` +
+    `<div class="ml-table-pagebreak-gap-space"></div>` +
+    `<div class="ml-table-pagebreak-gap-top"></div>` +
+    `</div>` +
+    `</div>`
+  );
+}
+
 /**
  * Show a cell the way the PDF/HTML export shows it: inline HTML from the safe
  * subset rendered, entities resolved (see tablecell.ts). The markdown source
  * stays in `data-raw` — a rendered cell reads back through `textContent` as
  * flattened text, so every commit path compares against `data-raw` and the
  * cell is switched back to its raw source while focused for editing.
+ *
+ * `splits`, when given, means this ONE cell is itself taller than a page:
+ * its raw text is sliced at each split's offset and rendered as separate
+ * segments (still through the same cellDisplayHtml as any other cell) with
+ * an inline divider between them — see resolveTableDivider/TableDivider.
  */
-function showCell(cell: HTMLElement, raw: string) {
+function showCell(cell: HTMLElement, raw: string, splits?: CellSplit[]) {
   cell.dataset.raw = raw;
-  if (cellHasRichContent(raw)) cell.innerHTML = cellDisplayHtml(raw);
-  else cell.textContent = raw;
+  if (splits !== undefined && splits.length > 0) {
+    let html = "";
+    let prev = 0;
+    for (const s of splits) {
+      html += cellDisplayHtml(raw.slice(prev, s.offset));
+      html += buildInlinePageBreakHtml(s.page);
+      prev = s.offset;
+    }
+    html += cellDisplayHtml(raw.slice(prev));
+    cell.innerHTML = html;
+  } else if (cellHasRichContent(raw)) {
+    cell.innerHTML = cellDisplayHtml(raw);
+  } else {
+    cell.textContent = raw;
+  }
 }
 
 /** The markdown source of a cell, regardless of whether it is rendered. */
@@ -241,7 +346,12 @@ function cellRaw(cell: HTMLElement): string {
 /** Swap a rendered cell to its raw source so typing edits real markdown. */
 function revealCellSource(cell: HTMLElement) {
   const raw = cellRaw(cell);
-  if (cell.textContent === raw) return; // plain cell: nothing was rendered
+  // A plain cell (no element children) that reads back unchanged had
+  // nothing rendered — nothing to reveal. Checking for element children too
+  // (not just the string comparison) means a divider's own label text can
+  // never be mistaken for "nothing was rendered": any element children at
+  // all — rich content OR a page-break divider — always gets revealed.
+  if (cell.children.length === 0 && cell.textContent === raw) return;
   cell.textContent = raw;
   // Content length just changed under the caret, so a click-derived offset is
   // meaningless. Put it at the end, the same convention focusCell() uses.
@@ -260,10 +370,28 @@ function buildTablePageBreakRow(page: number, cols: number): HTMLElement {
   tr.className = "ml-table-pagebreak";
   const td = document.createElement("td");
   td.colSpan = cols;
-  const label = document.createElement("span");
-  label.className = "ml-table-pagebreak-num";
-  label.textContent = `Page ${page - 1}`;
-  td.appendChild(label);
+  // A <tr>/<td> can't bleed past the table's own width the way .cm-page-gap
+  // bleeds past the page card's padding (table layout ignores cell margins)
+  // — so the TD just reserves the right VERTICAL space in the table's own
+  // flow, and this inner wrapper escapes it via absolute positioning,
+  // bleeding left/right the same amount .cm-page-gap does, without widening
+  // the table itself. Same bottom-margin/gap/top-margin structure as the
+  // inline mid-cell divider and the standalone .cm-page-gap — one
+  // consistent "this is a page break" look everywhere.
+  const bleed = document.createElement("div");
+  bleed.className = "ml-table-pagebreak-bleed";
+  const bottom = document.createElement("div");
+  bottom.className = "ml-table-pagebreak-gap-bottom";
+  const num = document.createElement("span");
+  num.className = "cm-page-num";
+  num.textContent = String(page - 1);
+  bottom.appendChild(num);
+  const space = document.createElement("div");
+  space.className = "ml-table-pagebreak-gap-space";
+  const top = document.createElement("div");
+  top.className = "ml-table-pagebreak-gap-top";
+  bleed.append(bottom, space, top);
+  td.appendChild(bleed);
   tr.appendChild(td);
   return tr;
 }
@@ -344,6 +472,24 @@ function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
   // --- the grid --------------------------------------------------------------
   const table = document.createElement("table");
   table.className = "ml-table";
+  // Group dividers: "before the whole row" (unique per row) vs. "inside one
+  // cell" (a single tall cell can need more than one, if it spans 3+ pages
+  // on its own — keyed by "row:col", sorted so segments slice in order).
+  const dividerBeforeRow = new Map<number, number>();
+  const cellSplits = new Map<string, CellSplit[]>();
+  for (const d of widget.dividers) {
+    if (d.splitCol === undefined || d.splitOffset === undefined) {
+      dividerBeforeRow.set(d.row, d.page);
+      continue;
+    }
+    const key = `${d.row}:${d.splitCol}`;
+    const list = cellSplits.get(key) ?? [];
+    list.push({ offset: d.splitOffset, page: d.page });
+    cellSplits.set(key, list);
+  }
+  for (const list of cellSplits.values())
+    list.sort((a, b) => a.offset - b.offset);
+
   const mkCell = (
     tag: "th" | "td",
     row: number,
@@ -355,7 +501,7 @@ function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
     cell.contentEditable = "plaintext-only";
     cell.dataset.row = String(row);
     cell.dataset.col = String(col);
-    showCell(cell, text);
+    showCell(cell, text, cellSplits.get(`${row}:${col}`));
     if (align !== "none") cell.style.textAlign = align;
     return cell;
   };
@@ -367,7 +513,6 @@ function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
   thead.appendChild(hr);
   table.appendChild(thead);
   const tbody = document.createElement("tbody");
-  const dividerBeforeRow = new Map(widget.dividers.map((d) => [d.row, d.page]));
   model.rows.forEach((cells, r) => {
     const page = dividerBeforeRow.get(r);
     if (page !== undefined)
@@ -414,8 +559,11 @@ function buildTableDom(view: EditorView, widget: TableWidget): HTMLElement {
     const text = cell.textContent ?? "";
     const before = cellRaw(cell);
     // Re-render: on a real edit the widget is rebuilt from the document and
-    // this node is discarded, but an unchanged cell must go back to rendered.
-    showCell(cell, text);
+    // this node is discarded, but an unchanged cell must go back to
+    // rendered — including its divider, if it has one, or blurring a split
+    // cell without editing it would strand it undivided until an unrelated
+    // edit forces a full rebuild.
+    showCell(cell, text, cellSplits.get(`${row}:${col}`));
     if (text !== before) {
       commitModel(
         view,


### PR DESCRIPTION
## Summary
- A table in the live editor is rendered as a single `Decoration.replace` spanning its entire source range (`tablewidget.ts`'s `buildDecorations`), substituting one opaque interactive `<table>` for the raw markdown. CodeMirror can't paint anything for positions strictly inside a replaced range, so a page-break divider from `pagination.ts`'s `pageBreaksField` had nowhere to render whenever its computed position landed inside a table.
- Confirmed via a 150-row table spanning 6 pages: `extractPageBreaks()` computed 5 perfectly correct break positions (verified by feeding the real captured Paged.js measurement DOM directly into that function), yet the live view showed zero dividers anywhere in the table. Export/PDF was unaffected since it doesn't go through this live-preview decoration layer.
- Fix: since the table owns one contiguous DOM region regardless of what CodeMirror decorations can do inside it, `TableWidget` now renders the divider itself, as an extra row inside its own `<table>`:
  - `pagination.ts` exposes `pageBreakPositions(state)`, reading `pageBreaksField` as plain `{pos, page}` data rather than depending on decoration/widget internals.
  - `tablewidget.ts` maps each break position landing strictly inside a table's range to a 0-based row index (a GFM table row is always exactly one physical source line) and threads that into `TableWidget`, which renders a new `.ml-table-pagebreak` row at the right spot. `eq()` now compares dividers too, and `tableField` rebuilds on `setPageBreaks` (previously only on `docChanged`/`refreshTables`), so a pagination-only update actually re-renders the table.
  - A break at or before the table's own start is unaffected — that position sits outside the replaced range and already renders via the normal standalone `.cm-page-gap` mechanism.

## Verification
- [x] `npx tsc --noEmit`
- [x] `npm test` (538 passing, including new tests for `pageBreakPositions()` and the table-internal divider: correct row placement, no divider for out-of-range breaks, divider moves on recomputation, existing tables unaffected)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Live-verified via CDP: the same 150-row/6-page repro now shows 5 divider rows, evenly spaced at the same rows (29→30, 59→60, ...) the real PDF/export pagination breaks at.
- [x] Confirmed cell editing immediately before and after a divider row is unaffected.

## Test plan
- [ ] Paste or type a table long enough to span 2+ printed pages and confirm a divider row appears inside it at the right spot, matching the PDF/print preview.
- [ ] Confirm a short table (single page) is visually unchanged.
- [ ] Confirm table editing (Tab/Enter navigation, +Row/−Row, cell focus) still works normally around a divider row.