### PR TITLE
fix(styles): clamp the cursor's height at multi-line block-widget boundaries

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1109,6 +1109,16 @@ html.theme-dark .brand-dark {
 
 #editor .cm-cursor {
   border-left-width: 2px;
+  /* CodeMirror sets the cursor's height directly from coordsAtPos(), which
+     misresolves right at the edge of a multi-line block-replace widget (a
+     table spanning several pages, say) to the widget's own top/bottom —
+     the cursor then renders as tall as the whole table. max-height clamps
+     the used value regardless of that inline height. Sized to ordinary
+     text (14.67px baseline * 1.5 line-height ≈ 22px, plus a little
+     headroom) rather than trying to also cover every heading size at every
+     zoom level — a slightly short cursor on a large heading is a much
+     smaller issue than one spanning a whole table. */
+  max-height: 26px;
 }
 
 /* Dark mode: the default caret is nearly invisible on the dark canvas, so


### PR DESCRIPTION
## Summary
- CodeMirror sets a collapsed cursor's height directly from `coordsAtPos()`'s result (`RectangleMarker.forRange`, `@codemirror/view`). Right at the edge of a multi-line `Decoration.replace` widget (most visibly, a table spanning several printed pages — see PR #42), that call can resolve to the widget's own top/bottom instead of the adjacent line, so the cursor renders as tall as the whole widget instead of a normal line height.
- `max-height` on `#editor .cm-cursor` clamps the used value regardless of that inline height, sized to ordinary text (14.67px baseline × 1.5 line-height ≈ 22px, plus a little headroom) rather than trying to also cover every heading size at every zoom level — a slightly short cursor on a large heading is a much smaller issue than one spanning a whole table.
- Independent of PR #42 (this is a general CodeMirror rendering fix, not specific to tables), so it's its own PR/branch off `main` rather than stacked on that one.

## Verification
- [x] `npx tsc --noEmit`
- [x] `npm test` (532 passing — pure CSS change, no logic touched)
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Live-verified in the running app: cursor next to a multi-page table now renders at normal height instead of spanning the table.

## Test plan
- [ ] Click immediately before/after a table (especially one spanning multiple pages) and confirm the cursor looks like a normal single-line caret.
- [ ] Confirm cursor height still looks reasonable on a heading line.