### PR TITLE
chore(release): bump to 1.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,11 @@
 # Windows (NSIS, per-user, no admin) is the primary target and must work;
 # macOS and Linux are wired up but secondary.
 #
-# NOTE macOS: distribution eventually needs a paid Apple Developer account
-# for code signing / notarization. Until then the .dmg is UNSIGNED — Gatekeeper
-# will warn, and users must right-click > Open. Do not ship broadly this way.
+# NOTE macOS: there is no Apple Developer account and none is planned, so the
+# .dmg is UNSIGNED and unnotarized. Gatekeeper refuses to open it on a plain
+# double-click ("app is damaged"); users must right-click > Open, then confirm
+# Open again. release.yml's release body spells this out for anyone
+# downloading it.
 name: build
 
 # Continuous integration: verify tests + that installers build on every push to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,18 @@
 #
 #     git tag v1.0.0 && git push origin v1.0.0
 #
-# It runs the tests, builds the Windows installer and the Linux AppImage, and
-# creates a DRAFT GitHub Release with both attached — you review and click
-# "Publish" so nothing goes public by accident. (Can also be run manually from
-# the Actions tab via workflow_dispatch, from a tagged commit.)
+# It runs the tests, builds the Windows installer, the macOS .dmg and the Linux
+# AppImage, and creates a DRAFT GitHub Release with all three attached — you
+# review and click "Publish" so nothing goes public by accident. (Can also be
+# run manually from the Actions tab via workflow_dispatch, from a tagged
+# commit.)
 #
-# Windows is the tested, primary target. Linux ships too, labeled best-effort in
-# the release body below — it is community-tested (works on at least one real
-# machine outside CI), not exercised as broadly as Windows. macOS stays
-# verification-only in build.yml: unlike the other two, an unsigned/unnotarized
-# .dmg is a hard Gatekeeper block for most users rather than a click-through
-# warning, so shipping it needs a paid Apple Developer account first.
+# Windows is the tested, primary target. macOS and Linux ship too, both
+# labeled best-effort in the release body below. Neither is signed: there is
+# no Apple Developer account (no plan to get one), so the .dmg is unsigned and
+# unnotarized — a harder Gatekeeper block than Windows's SmartScreen
+# click-through, spelled out explicitly in the release body rather than left
+# for someone to discover as "app is damaged."
 name: release
 
 on:
@@ -131,18 +132,18 @@ jobs:
   release:
     if: ${{ !inputs.updater_dry_run }}
     needs: [version, gate]
-    # Two platforms, one release: both legs target the same tagName, and
+    # Three platforms, one release: all three legs target the same tagName, and
     # tauri-action's own find-or-create-by-tag logic (not a separate
     # create-release job) is what upstream's own multi-platform example relies
     # on, so this follows that rather than inventing a second pattern.
-    # fail-fast: false, matching build.yml — a Linux bundle failure must not
-    # cancel the Windows upload that was already in flight, and the draft
-    # state is what makes an incomplete pair of assets safe to notice and fix
-    # before publishing rather than something that ships silently.
+    # fail-fast: false, matching build.yml — one bundle failing must not cancel
+    # the others already in flight, and the draft state is what makes an
+    # incomplete set of assets safe to notice and fix before publishing rather
+    # than something that ships silently.
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, ubuntu-22.04]
+        platform: [windows-latest, macos-latest, ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: write # create the GitHub Release and upload the installer
@@ -190,8 +191,12 @@ jobs:
           releaseBody: >-
             See the assets below to download and install. The Windows installer
             is unsigned (SmartScreen may warn: More info → Run anyway). The
-            Linux AppImage is community-tested, best-effort — please file an
-            issue if you hit a problem with it.
+            macOS .dmg is unsigned and unnotarized (no Apple Developer account)
+            — Gatekeeper will refuse to open it as "damaged" on a plain
+            double-click; right-click (or Control-click) the app in the .dmg
+            and choose Open, then confirm Open again in the dialog that
+            follows. The Linux AppImage is community-tested, best-effort.
+            Please file an issue if you hit a problem with either.
           # Draft is unconditional: it is the safety property, so nothing gets
           # to make it depend on the tag.
           releaseDraft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Monoleaf are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-08-24
 
 ### Fixed
 
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page-break divider landing inside it had nowhere to draw — the divider now
   renders as a row inside the table itself, at the same row the real
   PDF/print output breaks on.
+- **A page break landing inside a single tall cell now shows precisely
+  where the PDF actually breaks, instead of only at row boundaries.** A
+  cell long enough to span a page on its own (a `<br>`-separated list, say)
+  has no row to anchor a divider to; the divider is now rendered inline
+  inside the cell's own content, at the exact character position the real
+  PDF broke at.
+- **The gap between pages, and the divider inside a split table, now match
+  the editor's actual canvas color** instead of a similar but slightly
+  different grey that never quite lined up with the background behind the
+  page.
+- **The text cursor no longer renders as tall as an entire table** when
+  placed at the edge of a table that spans multiple pages. It's now clamped
+  to the height it would have in ordinary text.
 
 ## [1.2.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Page breaks are no longer invisible inside a table that spans multiple
   pages.** A table is rendered in the editor as one interactive grid, so a
-  page-break divider landing inside it had nowhere to draw — the divider now
+  page-break divider landing inside it had nowhere to draw: the divider now
   renders as a row inside the table itself, at the same row the real
   PDF/print output breaks on.
 - **A page break landing inside a single tall cell now shows precisely
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   IBM Plex Mono for code blocks and the raw view. All six are bundled with
   the app (SIL Open Font License) rather than drawn from whatever is
   installed on your system, so a document renders and paginates identically
-  everywhere — the same reason page size and margins already travel with the
+  everywhere, the same reason page size and margins already travel with the
   file. The choice is saved in the document itself and carried into PDF and
   HTML exports; HTML exports embed the font directly so the file looks right
   even on a machine that doesn't have it installed.
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PDF and print output now actually uses the page's intended typography.**
   The stylesheet that sets the 11pt body size, heading sizes, line spacing,
   justified text and code font was scoped to an element ID that Paged.js
-  rewrites internally, so none of those rules ever matched — printed
+  rewrites internally, so none of those rules ever matched: printed
   documents silently fell back to a 16px browser default instead. Exports
   now render at the intended size, so a document has noticeably more text
   per page and the printed page count may be lower than before.
@@ -79,7 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "What's new" disclosure under the offer shows the release notes, instead of
   just a bare version number.
 - **Skip a specific update version.** A "Skip this version" button lets you
-  decline one release without turning update checks off entirely — a later
+  decline one release without turning update checks off entirely. A later
   "Check for updates" still offers it, and the next release is unaffected.
 - **Periodic update rechecks.** Monoleaf now checks for updates roughly once a
   day while it stays open, not only at startup, so a long-running session

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ What you write stays plain Markdown that any editor, GitHub, or an LLM can read.
 
 [![version](https://img.shields.io/github/v/release/vibingbiochemist/Monoleaf?label=version&color=E8A33D)](https://github.com/vibingbiochemist/Monoleaf/releases)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![platform](https://img.shields.io/badge/platform-Windows_%26_Linux-0078D6)](https://github.com/vibingbiochemist/Monoleaf/releases)
+[![platform](https://img.shields.io/badge/platform-Windows_%2C_macOS_%26_Linux-0078D6)](https://github.com/vibingbiochemist/Monoleaf/releases)
 [![built with Tauri](https://img.shields.io/badge/built%20with-Tauri%20%2B%20CodeMirror-24C8DB)](https://tauri.app)
 
 [**monoleaf.org**](https://monoleaf.org) · [Download](https://github.com/vibingbiochemist/Monoleaf/releases) · [Report an issue](https://github.com/vibingbiochemist/Monoleaf/issues)
@@ -142,6 +142,19 @@ Run the installer.
 > a free tool with one maintainer, so it is **not planned** rather than pending. If
 > you would rather not run an unsigned binary, build it yourself: see below.
 
+### macOS
+
+Open the `.dmg` and drag Monoleaf into Applications.
+
+> **Note:** the `.dmg` is **unsigned and unnotarized** — there is no Apple
+> Developer account, and none is planned; the yearly cost is hard to justify
+> for a free tool with one maintainer. Gatekeeper will refuse to open the app
+> on a plain double-click ("Monoleaf is damaged and can't be opened," or
+> similar). **Right-click (or Control-click) the app and choose Open**, then
+> confirm **Open** again in the dialog that follows — this only needs doing
+> once. If you would rather not run an unsigned binary, build it yourself: see
+> below.
+
 ### Linux
 
 Download the `.AppImage`, make it executable, and run it:
@@ -169,25 +182,22 @@ npm run tauri build    # build the installer → src-tauri/target/release/bundle
 
 ### Platform support
 
-**Windows and Linux are distributed; Windows is the more thoroughly tested of
-the two.** Monoleaf is a Tauri app, so the same source also builds on macOS,
-and `npm run tauri build` produces a `.dmg` there. Where each platform stands:
+**Windows, macOS and Linux are all distributed; Windows is the most
+thoroughly tested of the three.** Where each platform stands:
 
 - **Windows**: primary target, most exercised.
+- **macOS**: shipped as an unsigned, unnotarized `.dmg` — see the note in the
+  download section above for the Gatekeeper workaround. Community-tested
+  rather than exercised as broadly as Windows.
 - **Linux**: shipped as an AppImage, but community-tested rather than
   exercised as broadly as Windows — see the note in the download section
   above.
-- **macOS**: **not distributed**. CI builds the `.dmg` on every push, so a
-  compile break would be caught, but nobody has run it and checked that the
-  editor behaves, and an unsigned/unnotarized `.dmg` hits Gatekeeper hard
-  enough (not a simple click-through, unlike Windows or Linux) that shipping
-  it well needs a paid Apple Developer account first.
 - Everything the editor does is portable in principle. Native spell-checking is
   the one Windows-specific feature, and it is compiled out elsewhere rather than
   breaking the build.
 
-If you build on macOS, or hit anything on Linux, reports either way are
-welcome — that is the fastest route to making both fully supported.
+If you hit anything on macOS or Linux, reports are welcome — that is the
+fastest route to making both as thoroughly exercised as Windows.
 
 ## Keyboard shortcuts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monoleaf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monoleaf",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monoleaf",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A portable, WYSIWYG Markdown editor — one file, single source of truth.",
   "license": "MIT",
   "author": "vibingbiochemist <info@monoleaf.org>",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "monoleaf"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "pdf-extract",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoleaf"
-version = "1.2.0"
+version = "1.2.1"
 description = "Monoleaf - a portable, single-file markdown editor"
 authors = ["vibingbiochemist <info@monoleaf.org>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Monoleaf",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "org.monoleaf.app",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- Version bump to 1.2.1 covering the fixes merged in #42 and #43: the precise mid-cell page-break divider, the page-gap/divider canvas-color match, and the cursor height clamp at table boundaries.
- CHANGELOG entries added for the three follow-on fixes that landed after the initial table-divider commit (row-level dividers already had an entry).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format:check`