### PR TITLE
fix(paste): stop regex-stripped <style>/<xml>/<o:p> from reconstituting

### DIFF
--- a/src/paste.test.ts
+++ b/src/paste.test.ts
@@ -223,6 +223,28 @@ describe("htmlToMarkdown (paste with formatting)", () => {
     expect(htmlToMarkdown(wordHtml)).toBe("Hello **Word**");
   });
 
+  it("doesn't leak <style>/<xml> content reconstituted by splitting the tag across removed text", () => {
+    // A regex that removes "<style ...>...</style>" as one literal span in a
+    // single pass can be defeated: split the delimiter so the leftover
+    // prefix/suffix concatenate into a NEW, well-formed tag around
+    // attacker-chosen text that a later `</style>` (never part of the
+    // removed match) legitimately closes.
+    //   "<sty" + "<style>x</style>" + "le>PAYLOAD</style>"
+    // The middle block is the only match in a single global pass, so it
+    // alone gets removed, leaving "<sty" + "le>PAYLOAD</style>" =
+    // "<style>PAYLOAD</style>" — a clean element whose text content
+    // (PAYLOAD) then survives verbatim into the output. Handling
+    // style/xml removal on turndown's parsed tree (see service()) instead
+    // of via regex closes this: the tag is dropped by its real, parsed
+    // identity, not reconstructed from adjacent decoy fragments.
+    expect(
+      htmlToMarkdown("<p><sty<style>x</style>le>PAYLOAD</style></p>"),
+    ).not.toBe("PAYLOAD");
+    expect(
+      htmlToMarkdown("<p><x<xml>x</xml>ml>PAYLOAD</xml></p>"),
+    ).not.toBe("PAYLOAD");
+  });
+
   it("collapses blank-line pileups", () => {
     const md = htmlToMarkdown("<div><div><p>a</p></div></div><p>b</p>");
     expect(md).toBe("a\n\nb");

--- a/src/paste.test.ts
+++ b/src/paste.test.ts
@@ -240,9 +240,9 @@ describe("htmlToMarkdown (paste with formatting)", () => {
     expect(
       htmlToMarkdown("<p><sty<style>x</style>le>PAYLOAD</style></p>"),
     ).not.toBe("PAYLOAD");
-    expect(
-      htmlToMarkdown("<p><x<xml>x</xml>ml>PAYLOAD</xml></p>"),
-    ).not.toBe("PAYLOAD");
+    expect(htmlToMarkdown("<p><x<xml>x</xml>ml>PAYLOAD</xml></p>")).not.toBe(
+      "PAYLOAD",
+    );
   });
 
   it("collapses blank-line pileups", () => {

--- a/src/paste.ts
+++ b/src/paste.ts
@@ -25,6 +25,24 @@ function service(): TurndownService {
   // Our house inline-HTML constructs survive as-is.
   td.keep(["u", "mark"]);
 
+  // Word's <style>/<xml> scaffolding, dropped node-and-contents. Done here
+  // (on turndown's own parsed tree) rather than by regex on the raw string:
+  // a regex removing "<style ...>...</style>" as one literal span can be
+  // defeated by an attacker splitting the delimiter across the boundary —
+  // e.g. "<sty<style>x</style>le>PAYLOAD" removes the inner block and
+  // concatenates the leftovers back into "<style>PAYLOAD", reconstituting
+  // the very tag the regex was meant to strip. A real parser can't be fooled
+  // this way: it tokenizes tags by position, not by string content.
+  td.remove(["style", "xml"] as (keyof HTMLElementTagNameMap)[]);
+
+  // Word's <o:p> paragraph markers: unwrap (keep the text, drop the tag) —
+  // same reconstitution hazard as <style> above, so handled structurally
+  // here rather than via `<\/?o:p[^>]*>` regex stripping.
+  td.addRule("msoParagraphMarker", {
+    filter: ["o:p"] as unknown as (keyof HTMLElementTagNameMap)[],
+    replacement: (content) => content,
+  });
+
   // GFM strikethrough must be double-tilde: a single tilde is subscript in
   // our enhanced dialect.
   td.addRule("strikethrough", {
@@ -273,7 +291,11 @@ function alignmentOf(el: HTMLElement): string | null {
     : null;
 }
 
-/** Strip Word's clipboard scaffolding before conversion. */
+/**
+ * Strip Word's clipboard scaffolding before conversion. <style>/<xml>/<o:p>
+ * are handled structurally in service()'s turndown rules instead of here —
+ * see the comment there for why regex can't safely remove those.
+ */
 function cleanWordHtml(html: string): string {
   return (
     html
@@ -286,9 +308,6 @@ function cleanWordHtml(html: string): string {
       // it's how Word marks its fake-list bullet/number spans — so only the
       // marker tags themselves are stripped, never what's between them.
       .replace(/<!\[(?:if\b[^\]]*|endif)\]>/gi, "")
-      .replace(/<\/?o:p[^>]*>/gi, "")
-      .replace(/<style[\s\S]*?<\/style>/gi, "")
-      .replace(/<xml[\s\S]*?<\/xml>/gi, "")
   );
 }
 


### PR DESCRIPTION
## What

`cleanWordHtml` (src/paste.ts) stripped Word's `<style>`/`<xml>`/`<o:p>` clipboard scaffolding via regex, removing each as a single literal span (`<style[\s\S]*?<\/style>`, etc.). That pattern is vulnerable to a classic reconstitution attack: split the opening delimiter across the block being removed, and the leftover prefix/suffix concatenate back into a brand-new, well-formed tag around attacker-chosen text.

Concretely: `"<sty" + "<style>x</style>" + "le>PAYLOAD</style>"` — the middle block is the only match found in the single global pass, so removing it leaves `"<sty" + "le>PAYLOAD</style>"` = `"<style>PAYLOAD</style>"`. That reconstituted element's text content then survives verbatim into the converted markdown. Verified empirically: this exact construction leaked `PAYLOAD` cleanly against the prior implementation (see the new test in `paste.test.ts`, confirmed failing against `main` before this change).

## Fix

Moved `<style>`/`<xml>`/`<o:p>` handling from pre-parse regex onto turndown's own parsed DOM tree (`td.remove([...])` + an unwrap rule for `o:p`), instead of string surgery on the raw HTML. A real parser tokenizes tags by position, not by string content, so it can't be fooled by an attacker's adjacent decoy fragments the way a regex scan can.

Left the two conditional-comment regexes (`<!--[if ...]>...<![endif]-->` and `<![if ...]>...<![endif]>`) as-is — they weren't flagged, and their failure mode is different: any leftover fragment from an imperfect strip still decays into an inert bogus-comment token under real HTML parsing (turndown ignores comment nodes), rather than a valid, content-bearing element. That asymmetry is why only the block-removal patterns needed a structural fix.

## How this was found

vibingbiochemist/Monoleaf_web's `upstream-sync` pipeline had two independent bugs (a `join(files, '\n')` expression bug and a disabled PR-creation setting) that meant it had never actually landed a sync PR since the repo's initial import. Once both were fixed and a backlog catch-up PR finally ran real diffs through GitHub's default CodeQL setup for the first time, it flagged this as "incomplete multi-character sanitization." Confirmed the bug is real (not a static-analysis false positive) and pre-existing here, not introduced by the web port.

## Verified locally

- `npm test` — 550/550 passing, including a new regression test that fails against the prior implementation and passes against this fix
- `npx tsc --noEmit` — clean
- `npx eslint .` — clean
