### PR TITLE
fix(ci): add fontEmbeds/fontfaces/fonts to notify-web-port SHARED_FILES

### DIFF
--- a/.github/workflows/notify-web-port.yml
+++ b/.github/workflows/notify-web-port.yml
@@ -58,6 +58,11 @@ jobs:
           src/document.test.ts
           src/export.ts
           src/export.test.ts
+          src/fontEmbeds.ts
+          src/fontEmbeds.test.ts
+          src/fontfaces.ts
+          src/fonts.ts
+          src/fonts.test.ts
           src/footnotes.ts
           src/footnotes.test.ts
           src/htmlcomment.ts


### PR DESCRIPTION
All three are portable (plain npm `@fontsource-*` imports via Vite, nothing Tauri-specific) but were never added to `SHARED_FILES` when the font feature shipped, so they silently never dispatched to Monoleaf_web. Manually backfilling the files themselves in Monoleaf_web separately; this closes the gap for future pushes.