### PR TITLE
Render local (on-disk) images in the live preview

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
 name = "monoleaf"
 version = "1.2.1"
 dependencies = [
+ "base64 0.22.1",
  "pdf-extract",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2.10.1"
 pdf-extract = "0.12"
+base64 = "0.22"
 
 # The `windows` crate is only used by the (Windows-only) spell-check module, so
 # gate it to Windows targets. Left in [dependencies] it would drag the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
@@ -373,6 +374,49 @@ fn read_file(path: String) -> Result<String, String> {
 fn write_file(path: String, contents: String) -> Result<(), String> {
     validate_write_path(&path, ALLOW_NETWORK_PATHS.load(Ordering::Relaxed))?;
     fs::write(&path, contents.as_bytes()).map_err(|e| format!("Failed to write {path}: {e}"))
+}
+
+/// Map a file extension to the MIME type an `<img>` needs to decode it.
+///
+/// An explicit, closed list rather than a guess (e.g. from magic bytes):
+/// anything not on it is refused with a clear error instead of being served
+/// under a wrong or made-up type.
+fn image_mime_type(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "svg" => Some("image/svg+xml"),
+        "bmp" => Some("image/bmp"),
+        "avif" => Some("image/avif"),
+        _ => None,
+    }
+}
+
+/// Read a local image referenced by a document (`![](diagram.png)`,
+/// `<img src="../x.png">`) and hand it back as a `data:` URL the webview can
+/// decode with no extra permission — the CSP already permits `img-src data:`
+/// unconditionally.
+///
+/// Guarded by the same [`validate_path`] every file command uses: the
+/// frontend already has this level of disk access via `read_file`, so this
+/// adds no new capability, only a new way to reach the same one. No separate
+/// directory scoping on top — see `validate_path`'s doc comment for why.
+#[tauri::command]
+fn read_image_as_data_url(path: String) -> Result<String, String> {
+    validate_path(&path, ALLOW_NETWORK_PATHS.load(Ordering::Relaxed))?;
+    let ext = std::path::Path::new(&path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let mime = ext
+        .as_deref()
+        .and_then(image_mime_type)
+        .ok_or_else(|| format!("{path} is not a supported image type"))?;
+    let bytes = fs::read(&path).map_err(|e| format!("Failed to read {path}: {e}"))?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{mime};base64,{encoded}"))
 }
 
 /// Convert a PDF to Markdown for opening as a new, unsaved document.
@@ -962,6 +1006,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             read_file,
             write_file,
+            read_image_as_data_url,
             set_allow_network_paths,
             import_pdf_as_markdown,
             spell_suggest,
@@ -1049,6 +1094,76 @@ mod tests {
         let bad = std::env::temp_dir().join("monoleaf_evil.bat");
         assert!(write_file(bad.to_string_lossy().into_owned(), "x".into()).is_err());
         assert!(!bad.exists());
+    }
+
+    #[test]
+    fn read_image_as_data_url_round_trips_and_picks_mime_type() {
+        let cases: &[(&str, &str, &[u8])] = &[
+            (
+                "monoleaf_img_test.png",
+                "image/png",
+                b"\x89PNG not-a-real-image-but-bytes-are-bytes",
+            ),
+            (
+                "monoleaf_img_test.svg",
+                "image/svg+xml",
+                b"<svg xmlns='x'></svg>",
+            ),
+            (
+                "monoleaf_img_test.JPG",
+                "image/jpeg",
+                b"\xff\xd8\xff\xe0 pretend jpeg",
+            ),
+        ];
+        for (name, mime, bytes) in cases {
+            let path = std::env::temp_dir().join(name);
+            fs::write(&path, bytes).unwrap();
+
+            let data_url = read_image_as_data_url(path.to_string_lossy().into_owned()).unwrap();
+            let prefix = format!("data:{mime};base64,");
+            assert!(
+                data_url.starts_with(&prefix),
+                "{name}: expected prefix {prefix:?}, got {data_url:?}"
+            );
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(&data_url[prefix.len()..])
+                .unwrap();
+            assert_eq!(&decoded, bytes, "{name}: payload did not round-trip");
+
+            let _ = fs::remove_file(&path);
+        }
+    }
+
+    #[test]
+    fn read_image_as_data_url_rejects_non_image_extensions() {
+        for name in ["monoleaf_img_reject.txt", "monoleaf_img_reject.exe"] {
+            let path = std::env::temp_dir().join(name);
+            fs::write(&path, b"not an image").unwrap();
+            let result = read_image_as_data_url(path.to_string_lossy().into_owned());
+            assert!(result.is_err(), "{name} should have been refused");
+            let _ = fs::remove_file(&path);
+        }
+        // Extensionless, and a path that never existed: both are refused
+        // (the former on the extension check, the latter reaches fs::read
+        // only for a path that would have passed it).
+        assert!(read_image_as_data_url("no_extension_here".into()).is_err());
+    }
+
+    #[test]
+    fn read_image_as_data_url_rejects_network_paths_unless_allowed() {
+        // ALLOW_NETWORK_PATHS defaults to false and no other test in this
+        // binary flips it, so this observes the real default rather than a
+        // value another test happened to leave behind.
+        for path in [
+            r"\\attacker.test\share\note.png",
+            "//attacker.test/share/note.png",
+        ] {
+            assert_eq!(
+                read_image_as_data_url(path.to_string()),
+                Err(NETWORK_PATH_REFUSED.to_string()),
+                "not rejected: {path}"
+            );
+        }
     }
 
     /// Both file commands refuse UNC/network paths *unless the user has opted

--- a/src/livepreview.test.ts
+++ b/src/livepreview.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
 import { ensureSyntaxTree } from "@codemirror/language";
-import { EditorState } from "@codemirror/state";
-import { buildLivePreviewDecorations, paragraphGuard } from "./livepreview";
+import { Compartment, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import {
+  buildLivePreviewDecorations,
+  livePreviewExtensions,
+  paragraphGuard,
+} from "./livepreview";
 import { markdownForMode } from "./portability";
+import { setRemoteImagesAllowed } from "./remoteimages";
 
 interface Entry {
   from: number;
@@ -506,5 +513,59 @@ describe("page config", () => {
     const doc = `${PAGE_COMMENT}\n\n# Body\n`;
     // The comment's own range is not hidden while being edited.
     expect(hides(doc, 5).some((d) => d.from === 0)).toBe(false);
+  });
+});
+
+// Regresses a pre-existing bug, unrelated to any in-flight feature: found
+// while building a different reconfigure-based test, not something anyone
+// set out to fix. toggleRemoteImages (main.ts) flips remoteImagesAllowed and
+// dispatches liveCompartment.reconfigure(livePreviewExtensions()). Its own
+// comment says this "rebuilds the image widgets" — but livePreviewExtensions()
+// always returns the same `livePreviewPlugin` value, so
+// EditorView.updatePlugins finds it by reference in the previous spec array
+// and reuses the existing plugin instance instead of reconstructing it. The
+// reused instance's update() still runs, but before the fix in livepreview.ts,
+// none of its original four conditions (docChanged/selectionSet/
+// viewportChanged/syntax tree) are true for a bare reconfigure, so build()
+// never reran and an already-blocked remote image kept showing its
+// placeholder even after the setting was turned on. The fix — a fifth
+// condition checking `tr.reconfigured`, plus capturing `remoteBlocked` on the
+// widget so eq() actually notices the difference — covers this case.
+describe("toggling remote images on rebuilds an already-blocked widget", () => {
+  afterEach(() => setRemoteImagesAllowed(false));
+
+  it("clears the blocked placeholder and renders the image, via reconfigure", () => {
+    setRemoteImagesAllowed(false);
+
+    const compartment = new Compartment();
+    const doc = "![x](https://example.com/a.png)";
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const state = EditorState.create({
+      doc,
+      extensions: [
+        markdownForMode("enhanced"),
+        compartment.of(livePreviewExtensions()),
+      ],
+    });
+    ensureSyntaxTree(state, doc.length, 5000);
+    const view = new EditorView({ state, parent });
+    view.dispatch({ changes: { from: 0, insert: "" } });
+
+    expect(
+      view.dom.querySelector<HTMLElement>(".cm-image-blocked")?.title,
+    ).toContain("Not loaded: https://example.com/a.png");
+    expect(view.dom.querySelector("img.cm-live-image")).toBeNull();
+
+    setRemoteImagesAllowed(true);
+    // The exact call toggleRemoteImages (main.ts) makes.
+    view.dispatch({
+      effects: compartment.reconfigure(livePreviewExtensions()),
+    });
+
+    expect(view.dom.querySelector(".cm-image-blocked")).toBeNull();
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("https://example.com/a.png");
+    view.destroy();
   });
 });

--- a/src/livepreview.test.ts
+++ b/src/livepreview.test.ts
@@ -1,13 +1,18 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ensureSyntaxTree } from "@codemirror/language";
 import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
 import {
   buildLivePreviewDecorations,
   livePreviewExtensions,
   paragraphGuard,
 } from "./livepreview";
+import { setCurrentDocumentPath } from "./localimages";
 import { markdownForMode } from "./portability";
 import { setRemoteImagesAllowed } from "./remoteimages";
 
@@ -61,14 +66,16 @@ describe("no raw-syntax bleeds", () => {
     expect(hides(doc, 0)).toEqual([{ from: 2, to: 3, kind: "hide" }]);
   });
 
-  it("keeps a local image as alt text (syntax hidden)", () => {
+  it("renders a local image reference as a widget, same as https", () => {
+    // Resolving/loading is ImageWidget's job (see localimages.test.ts and the
+    // "local images" describe block below) — at the decoration-planning level
+    // a local reference gets a widget exactly like a remote one.
     const doc = "see ![a figure](img.png) here";
     const all = decos(doc, 0);
-    const h = all.filter((d) => d.kind === "hide");
-    // "![" hidden and "](img.png)" hidden; "a figure" stays visible.
-    expect(h).toContainEqual({ from: 4, to: 6, kind: "hide" });
-    expect(h).toContainEqual({ from: 14, to: 24, kind: "hide" });
-    expect(all.filter((d) => d.kind === "widget")).toEqual([]);
+    expect(all.filter((d) => d.kind === "hide")).toEqual([]);
+    expect(all.filter((d) => d.kind === "widget")).toEqual([
+      { from: 4, to: 24, kind: "widget" },
+    ]);
   });
 
   it("renders an https image as a widget", () => {
@@ -516,21 +523,206 @@ describe("page config", () => {
   });
 });
 
-// Regresses a pre-existing bug, unrelated to any in-flight feature: found
-// while building a different reconfigure-based test, not something anyone
-// set out to fix. toggleRemoteImages (main.ts) flips remoteImagesAllowed and
-// dispatches liveCompartment.reconfigure(livePreviewExtensions()). Its own
-// comment says this "rebuilds the image widgets" — but livePreviewExtensions()
-// always returns the same `livePreviewPlugin` value, so
-// EditorView.updatePlugins finds it by reference in the previous spec array
-// and reuses the existing plugin instance instead of reconstructing it. The
-// reused instance's update() still runs, but before the fix in livepreview.ts,
-// none of its original four conditions (docChanged/selectionSet/
-// viewportChanged/syntax tree) are true for a bare reconfigure, so build()
-// never reran and an already-blocked remote image kept showing its
+// ---------------------------------------------------------------------------
+// Local image widgets, mounted in a real EditorView so ImageWidget.toDOM
+// actually runs (the decoration-planning tests above only check that a
+// widget was scheduled, not what it renders).
+
+function mountLive(doc: string): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const state = EditorState.create({
+    doc,
+    extensions: [markdownForMode("enhanced"), livePreviewExtensions()],
+  });
+  ensureSyntaxTree(state, doc.length, 5000);
+  const view = new EditorView({ state, parent });
+  // Nudge it so the full parse (done above, off-view) is what gets rendered.
+  view.dispatch({ changes: { from: 0, insert: "" } });
+  return view;
+}
+
+/** Let the microtask queue (the invoke promise and its .then) drain. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// invokeMock is reset at the top of each test body rather than in a
+// beforeEach: resetting it from a hook was observed to make Vitest misreport
+// a properly-handled rejection in a later test as an uncaught error (the
+// mock's async-result tracking gets confused about which test a settled
+// promise belongs to). Resetting inline avoids that; see localimages.test.ts.
+describe("local image widgets", () => {
+  afterEach(() => setCurrentDocumentPath(null));
+
+  it("resolves a relative reference against the open document and renders it (Image)", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("data:image/png;base64,AAAA");
+    setCurrentDocumentPath("/docs/notes.md");
+
+    const view = mountLive("![a figure](img.png)");
+    await flush();
+
+    expect(invokeMock).toHaveBeenCalledWith("read_image_as_data_url", {
+      path: "/docs/img.png",
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,AAAA");
+    view.destroy();
+  });
+
+  it("renders an already-absolute local path without needing an open document (HTMLBlock)", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("data:image/png;base64,BBBB");
+    setCurrentDocumentPath(null);
+
+    const view = mountLive('<img src="/abs/pic.png" alt="pic">');
+    await flush();
+
+    expect(invokeMock).toHaveBeenCalledWith("read_image_as_data_url", {
+      path: "/abs/pic.png",
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,BBBB");
+    view.destroy();
+  });
+
+  it("resolves an inline <img> the same way as a standalone one (HTMLTag)", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("data:image/png;base64,CCCC");
+    setCurrentDocumentPath("/docs/notes.md");
+
+    // A distinct file name from the other cases in this describe block: the
+    // resolved-path cache in localimages.ts is module-global, so reusing
+    // "img.png" here would hit that cache instead of exercising this call site.
+    const view = mountLive('before <img src="inline.png" alt="x"> after');
+    await flush();
+
+    expect(invokeMock).toHaveBeenCalledWith("read_image_as_data_url", {
+      path: "/docs/inline.png",
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,CCCC");
+    view.destroy();
+  });
+
+  it("shows a distinct fallback for a relative reference in an unsaved document", async () => {
+    invokeMock.mockReset();
+    setCurrentDocumentPath(null);
+
+    const view = mountLive("![a figure](img.png)");
+    await flush();
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    const placeholder =
+      view.dom.querySelector<HTMLElement>(".cm-image-blocked");
+    expect(placeholder?.title).toBe("Save the document to load local images.");
+    expect(view.dom.querySelector("img.cm-live-image")).toBeNull();
+    view.destroy();
+  });
+
+  it("falls back to a placeholder when the read is rejected (non-image extension)", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValue(
+      "/docs/notes.txt is not a supported image type",
+    );
+    setCurrentDocumentPath("/docs/notes.md");
+
+    const view = mountLive("![attachment](notes.txt)");
+    await flush();
+    await flush(); // one more tick for the rejection handler
+
+    // Exactly one call, not two: two would mean a second widget instance (a
+    // stale one from a rebuild, say) independently triggered its own read,
+    // which happens to produce this same symptom (an extra, differently-timed
+    // rejection) rather than the harness quirk documented above.
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(view.dom.querySelector("img.cm-live-image")).toBeNull();
+    const placeholder =
+      view.dom.querySelector<HTMLElement>(".cm-image-blocked");
+    expect(placeholder?.title).toContain("Could not load");
+    view.destroy();
+  });
+});
+
+// Regresses saveFile's reconfigure call (main.ts) specifically — not just
+// resolution/rendering given a correct currentDocumentPath, which the tests
+// above already cover. A widget for the same url/alt/width is normally kept
+// as-is across a rebuild (see the comment on `cache` in localimages.ts): only
+// an explicit liveCompartment.reconfigure() forces every widget to run
+// toDOM() again, which is the mechanism that must fire on save for a
+// previously-unresolvable placeholder to clear. Fresh construction (as in
+// mountLive) would pass even if saveFile's reconfigure call were deleted, so
+// this uses its own Compartment and an explicit reconfigure dispatch,
+// mirroring main.ts's liveCompartment (main.ts:500) and what saveFile
+// (main.ts) actually dispatches, rather than folding the extension straight
+// into the EditorState's extensions array.
+describe("saving resolves a previously-unresolvable local image", () => {
+  afterEach(() => setCurrentDocumentPath(null));
+
+  it("clears the placeholder once the document has a path, via reconfigure", async () => {
+    invokeMock.mockReset();
+    setCurrentDocumentPath(null);
+
+    const compartment = new Compartment();
+    // A distinct file name from the other tests in this file: the
+    // resolved-path cache in localimages.ts is module-global, so reusing
+    // "img.png" with the same directory would hit another test's cache
+    // entry instead of exercising this reconfigure path.
+    const doc = "![a figure](save-test.png)";
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const state = EditorState.create({
+      doc,
+      extensions: [
+        markdownForMode("enhanced"),
+        compartment.of(livePreviewExtensions()),
+      ],
+    });
+    ensureSyntaxTree(state, doc.length, 5000);
+    const view = new EditorView({ state, parent });
+    view.dispatch({ changes: { from: 0, insert: "" } });
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(
+      view.dom.querySelector<HTMLElement>(".cm-image-blocked")?.title,
+    ).toBe("Save the document to load local images.");
+    expect(view.dom.querySelector("img.cm-live-image")).toBeNull();
+
+    invokeMock.mockResolvedValue("data:image/png;base64,EEEE");
+    setCurrentDocumentPath("/docs/notes.md");
+    // The same call saveFile (main.ts) makes after currentPath = path.
+    view.dispatch({
+      effects: compartment.reconfigure(livePreviewExtensions()),
+    });
+    await flush();
+
+    expect(view.dom.querySelector(".cm-image-blocked")).toBeNull();
+    expect(invokeMock).toHaveBeenCalledWith("read_image_as_data_url", {
+      path: "/docs/save-test.png",
+    });
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,EEEE");
+    view.destroy();
+  });
+});
+
+// Regresses a pre-existing bug, unrelated to local images: found while
+// building the test above, not something this task set out to fix.
+//
+// toggleRemoteImages (main.ts) flips remoteImagesAllowed and dispatches
+// liveCompartment.reconfigure(livePreviewExtensions()), same as saveFile
+// does now. Its own comment says this "rebuilds the image widgets" — but
+// livePreviewExtensions() always returns the same `livePreviewPlugin` value,
+// so EditorView.updatePlugins finds it by reference in the previous spec
+// array and reuses the existing plugin instance instead of reconstructing
+// it. The reused instance's update() still runs, but before the fix in
+// livepreview.ts, none of its four conditions (docChanged/selectionSet/
+// viewportChanged/syntax tree) are true for a bare reconfigure, so
+// build() never reran and an already-blocked remote image kept showing its
 // placeholder even after the setting was turned on. The fix — a fifth
-// condition checking `tr.reconfigured`, plus capturing `remoteBlocked` on the
-// widget so eq() actually notices the difference — covers this case.
+// condition checking `tr.reconfigured` — covers this case too.
 describe("toggling remote images on rebuilds an already-blocked widget", () => {
   afterEach(() => setRemoteImagesAllowed(false));
 

--- a/src/livepreview.test.ts
+++ b/src/livepreview.test.ts
@@ -708,6 +708,86 @@ describe("saving resolves a previously-unresolvable local image", () => {
   });
 });
 
+// Prediction to verify before assuming the eq() fix from the previous commit
+// covers this: currentDocumentPath is fixed and never changes here — only
+// whether the file exists does. resolvedLocalPath is identical before and
+// after (same url, same document path), so if eq() only compares
+// resolvedLocalPath/remoteBlocked/url/alt/width, it should report the two
+// widget instances equal and CodeMirror should keep the stale (failed)
+// placeholder, never calling toDOM() again on the freshly-succeeding widget.
+describe("loadFailureCount: retries a failure but not an unrelated edit", () => {
+  afterEach(() => setCurrentDocumentPath(null));
+
+  it("clears the placeholder once the file loads, via reconfigure", async () => {
+    invokeMock.mockReset();
+    setCurrentDocumentPath("/docs/notes.md");
+    // Set before the view is even constructed: the ViewPlugin's constructor
+    // calls build() -> toDOM() synchronously, so this is the mock the FIRST
+    // load sees, not a later reconfigure.
+    invokeMock.mockRejectedValueOnce("ENOENT: no such file");
+
+    const compartment = new Compartment();
+    const doc = "![a figure](retry-test.png)";
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const state = EditorState.create({
+      doc,
+      extensions: [
+        markdownForMode("enhanced"),
+        compartment.of(livePreviewExtensions()),
+      ],
+    });
+    ensureSyntaxTree(state, doc.length, 5000);
+    const view = new EditorView({ state, parent });
+    view.dispatch({ changes: { from: 0, insert: "" } });
+    await flush();
+    await flush();
+
+    expect(
+      view.dom.querySelector<HTMLElement>(".cm-image-blocked")?.title,
+    ).toContain("Could not load");
+    expect(view.dom.querySelector("img.cm-live-image")).toBeNull();
+
+    // The file now exists. currentDocumentPath is untouched — only the
+    // outcome of loading the same resolved path has changed.
+    invokeMock.mockResolvedValue("data:image/png;base64,FFFF");
+    view.dispatch({
+      effects: compartment.reconfigure(livePreviewExtensions()),
+    });
+    await flush();
+
+    expect(view.dom.querySelector(".cm-image-blocked")).toBeNull();
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,FFFF");
+    view.destroy();
+  });
+
+  // The other side of the fix above: `loadFailureCount` must stay unchanged
+  // for a path that has never failed, or every unrelated edit anywhere in
+  // the document would make eq() report a difference for every local image
+  // in the viewport and flicker them all back to an empty <img> while the
+  // (already-cached) promise resolves again.
+  it("does not re-invoke for an already-resolved image on an unrelated edit", async () => {
+    invokeMock.mockReset();
+    setCurrentDocumentPath("/docs/notes.md");
+    invokeMock.mockResolvedValue("data:image/png;base64,GGGG");
+
+    const view = mountLive("x ![a figure](no-retry-needed.png)");
+    await flush();
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    // An edit far from the image reference: real docChanged, not a
+    // reconfigure.
+    view.dispatch({ changes: { from: 0, insert: "y" } });
+    await flush();
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    const img = view.dom.querySelector<HTMLImageElement>("img.cm-live-image");
+    expect(img?.getAttribute("src")).toBe("data:image/png;base64,GGGG");
+    view.destroy();
+  });
+});
+
 // Regresses a pre-existing bug, unrelated to local images: found while
 // building the test above, not something this task set out to fix.
 //

--- a/src/livepreview.ts
+++ b/src/livepreview.ts
@@ -7,6 +7,7 @@ import { tags } from "@lezer/highlight";
 import { isRemoteUrl, remoteImagesAllowed } from "./remoteimages";
 import {
   getCurrentDocumentPath,
+  loadFailureCount,
   loadLocalImage,
   resolveLocalImagePath,
 } from "./localimages";
@@ -142,6 +143,14 @@ class ImageWidget extends WidgetType {
    * same reason as `remoteBlocked`: resolution depends on
    * `getCurrentDocumentPath()`, which is not part of url/alt/width. */
   private readonly resolvedLocalPath: string | null | undefined;
+  /** How many times a load of `resolvedLocalPath` had failed as of this
+   * widget's construction. `resolvedLocalPath` alone cannot tell a widget
+   * built right after a failure apart from one built on the next
+   * reconfigure where nothing else changed — the document didn't move, only
+   * whether the file loads did — so eq() needs this too, or a retry after a
+   * missing file appears would never redraw. See the `cache`/`failureCount`
+   * comments in localimages.ts. */
+  private readonly loadFailureCount: number;
 
   constructor(
     readonly url: string,
@@ -154,6 +163,10 @@ class ImageWidget extends WidgetType {
       isRemoteUrl(url) || isDataUrl(url)
         ? undefined
         : resolveLocalImagePath(url, getCurrentDocumentPath());
+    this.loadFailureCount =
+      this.resolvedLocalPath == null
+        ? 0
+        : loadFailureCount(this.resolvedLocalPath);
   }
   eq(other: ImageWidget) {
     return (
@@ -161,7 +174,8 @@ class ImageWidget extends WidgetType {
       other.alt === this.alt &&
       other.width === this.width &&
       other.remoteBlocked === this.remoteBlocked &&
-      other.resolvedLocalPath === this.resolvedLocalPath
+      other.resolvedLocalPath === this.resolvedLocalPath &&
+      other.loadFailureCount === this.loadFailureCount
     );
   }
 
@@ -969,9 +983,9 @@ const livePreviewPlugin = ViewPlugin.fromClass(
         // Rebuilding is only half of it: build() constructs a fresh
         // ImageWidget either way, but CodeMirror still decides whether to
         // redraw by comparing it to the previous one via eq() — see the
-        // `remoteBlocked`/`resolvedLocalPath` fields on ImageWidget for the
-        // other half, without which a fresh-but-eq()-equal widget would
-        // still keep its stale DOM.
+        // `remoteBlocked`/`resolvedLocalPath`/`loadFailureCount` fields on
+        // ImageWidget for the other half, without which a fresh-but-eq()-equal
+        // widget would still keep its stale DOM.
         update.transactions.some((tr) => tr.reconfigured)
       ) {
         [this.decorations, this.atomics] = this.build(update.view);

--- a/src/livepreview.ts
+++ b/src/livepreview.ts
@@ -5,6 +5,11 @@ import {
 } from "@codemirror/language";
 import { tags } from "@lezer/highlight";
 import { isRemoteUrl, remoteImagesAllowed } from "./remoteimages";
+import {
+  getCurrentDocumentPath,
+  loadLocalImage,
+  resolveLocalImagePath,
+} from "./localimages";
 import type { Tree } from "@lezer/common";
 import {
   Decoration,
@@ -115,6 +120,12 @@ class AdmonitionTitleWidget extends WidgetType {
   }
 }
 
+/** True for a `data:` URI — carries its bytes inline, reaches no network and
+ * needs no disk read, so it renders exactly like an https image. */
+function isDataUrl(url: string): boolean {
+  return /^data:/i.test(url.trim());
+}
+
 class ImageWidget extends WidgetType {
   /** Whether this is a remote image the reader has not opted into loading —
    * captured at construction, not re-read live in toDOM/eq, because eq()
@@ -122,8 +133,15 @@ class ImageWidget extends WidgetType {
    * live `remoteImagesAllowed()` call instead of a field, two widgets built
    * before and after the setting changed would still compare equal on
    * url/alt/width and CodeMirror would keep the stale (blocked) DOM instead
-   * of redrawing when the setting flips. */
+   * of redrawing — the exact bug fixed here for local images and, as a
+   * pre-existing bug, for the remote-images toggle. */
   private readonly remoteBlocked: boolean;
+  /** The resolved absolute path for a local reference, `null` if it cannot
+   * be resolved (no open document), or `undefined` if `url` is not a local
+   * reference at all (remote or data:). Captured at construction for the
+   * same reason as `remoteBlocked`: resolution depends on
+   * `getCurrentDocumentPath()`, which is not part of url/alt/width. */
+  private readonly resolvedLocalPath: string | null | undefined;
 
   constructor(
     readonly url: string,
@@ -132,36 +150,44 @@ class ImageWidget extends WidgetType {
   ) {
     super();
     this.remoteBlocked = isRemoteUrl(url) && !remoteImagesAllowed();
+    this.resolvedLocalPath =
+      isRemoteUrl(url) || isDataUrl(url)
+        ? undefined
+        : resolveLocalImagePath(url, getCurrentDocumentPath());
   }
   eq(other: ImageWidget) {
     return (
       other.url === this.url &&
       other.alt === this.alt &&
       other.width === this.width &&
-      other.remoteBlocked === this.remoteBlocked
+      other.remoteBlocked === this.remoteBlocked &&
+      other.resolvedLocalPath === this.resolvedLocalPath
     );
   }
-  toDOM(view: EditorView) {
-    const wrap = document.createElement("span");
-    wrap.className = "cm-image-wrap";
 
-    // A remote image the reader has not opted into is a *span*, not an <img>.
-    // An <img> with no src draws the browser's broken-image glyph with the alt
-    // text struck through it, which reads as an error when nothing is wrong —
-    // and there is no image to resize, so the drag handle is skipped too.
-    if (this.remoteBlocked) {
-      const blocked = document.createElement("span");
-      blocked.className = "cm-image-blocked";
-      blocked.dataset.blockedSrc = this.url;
-      blocked.textContent = this.alt !== "" ? this.alt : "remote image";
-      blocked.title = `Not loaded: ${this.url}\nTurn on “Load remote images” in settings to load it.`;
-      wrap.appendChild(blocked);
-      return wrap;
-    }
+  /** A quiet dashed-frame placeholder (alt text + tooltip), used for every
+   * "nothing is wrong, there is just no image to show yet" case: a remote
+   * fetch declined, a relative reference with no document to resolve it
+   * against, or a local read that failed. */
+  private placeholder(title: string): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-image-blocked";
+    span.dataset.blockedSrc = this.url;
+    span.textContent = this.alt !== "" ? this.alt : "image";
+    span.title = title;
+    return span;
+  }
 
+  /** Build the `<img>` + resize handle, append both to `wrap`, and return the
+   * `<img>` so a caller resolving asynchronously can set `.src` later. */
+  private buildImg(
+    view: EditorView,
+    wrap: HTMLElement,
+    src: string,
+  ): HTMLImageElement {
     const img = document.createElement("img");
     img.className = "cm-live-image";
-    img.src = this.url;
+    img.src = src;
     img.alt = this.alt;
     if (this.alt !== "") img.title = this.alt;
     if (this.width !== "") {
@@ -199,8 +225,65 @@ class ImageWidget extends WidgetType {
       document.addEventListener("mouseup", onUp);
     });
     wrap.appendChild(handle);
+    return img;
+  }
+
+  toDOM(view: EditorView) {
+    const wrap = document.createElement("span");
+    wrap.className = "cm-image-wrap";
+
+    // A remote image the reader has not opted into is a *span*, not an <img>.
+    // An <img> with no src draws the browser's broken-image glyph with the alt
+    // text struck through it, which reads as an error when nothing is wrong —
+    // and there is no image to resize, so the drag handle is skipped too.
+    if (this.remoteBlocked) {
+      wrap.appendChild(
+        this.placeholder(
+          `Not loaded: ${this.url}\nTurn on “Load remote images” in settings to load it.`,
+        ),
+      );
+      return wrap;
+    }
+
+    // Remote (allowed) and data: URIs need no Rust round trip — handing the
+    // URL straight to <img src> triggers the browser's own (async) decode,
+    // same as it always has.
+    if (this.resolvedLocalPath === undefined) {
+      this.buildImg(view, wrap, this.url);
+      return wrap;
+    }
+
+    // Everything else is a local file reference, already resolved (in the
+    // constructor) against the open document's directory, or used as-is if
+    // already absolute.
+    const resolved = this.resolvedLocalPath;
+    if (resolved === null) {
+      wrap.appendChild(
+        this.placeholder("Save the document to load local images."),
+      );
+      return wrap;
+    }
+
+    // The webview cannot read this path itself (no asset-protocol scope, no
+    // fs plugin) — read_image_as_data_url does it in Rust and hands back a
+    // data: URL. Returned synchronously with an empty src so toDOM never
+    // blocks; the invoke resolves later and sets it.
+    const img = this.buildImg(view, wrap, "");
+    loadLocalImage(resolved).then(
+      (dataUrl) => {
+        img.src = dataUrl;
+      },
+      (err) => {
+        // Whole wrap, not just the <img>: the drag handle built alongside it
+        // has nothing to resize once the load has failed.
+        wrap.replaceChildren(
+          this.placeholder(`Could not load: ${resolved}\n${err}`),
+        );
+      },
+    );
     return wrap;
   }
+
   ignoreEvent() {
     return true;
   }
@@ -479,24 +562,19 @@ export function buildLivePreviewDecorations(
         }
 
         case "Image": {
-          // https images render inline; other references (local files, etc.)
-          // stay as their alt text — the .md holds only the reference either
-          // way, never image bytes.
+          // Every reference gets a widget; the .md itself still holds only
+          // the reference, never image bytes — ImageWidget decides how to
+          // get from that reference to pixels (or a placeholder).
           const text = state.doc.sliceString(node.from, node.to);
           const close = text.indexOf("](");
           if (text.startsWith("![") && close >= 0) {
             const alt = text.slice(2, close);
             const url = text.slice(close + 2, text.length - 1).split(/\s+/)[0];
-            if (/^https?:\/\//i.test(url)) {
-              hideRange(
-                node.from,
-                node.to,
-                Decoration.replace({ widget: new ImageWidget(url, alt, "") }),
-              );
-            } else {
-              hideRange(node.from, node.from + 2); // "!["
-              hideRange(node.from + close, node.to); // "](url …)"
-            }
+            hideRange(
+              node.from,
+              node.to,
+              Decoration.replace({ widget: new ImageWidget(url, alt, "") }),
+            );
           }
           break;
         }
@@ -561,13 +639,13 @@ export function buildLivePreviewDecorations(
 
         case "HTMLBlock": {
           const blockText = state.doc.sliceString(node.from, node.to);
-          // A standalone <img …> block: render it (https) or hide it.
+          // A standalone <img …> block: every reference gets a widget.
           const imgM = /<img\b[^>]*>/i.exec(blockText);
           if (imgM !== null) {
             const info = parseImgTag(imgM[0]);
             const from = node.from + imgM.index;
             const to = from + imgM[0].length;
-            if (info !== null && /^https?:\/\//i.test(info.src)) {
+            if (info !== null) {
               hideRange(
                 from,
                 to,
@@ -619,10 +697,10 @@ export function buildLivePreviewDecorations(
 
         case "HTMLTag": {
           const tag = state.sliceDoc(node.from, node.to);
-          // Inline <img …>: render it (https) or hide it (no raw bleed).
+          // Inline <img …>: every reference gets a widget.
           if (/^<img\b/i.test(tag)) {
             const info = parseImgTag(tag);
-            if (info !== null && /^https?:\/\//i.test(info.src)) {
+            if (info !== null) {
               hideRange(
                 node.from,
                 node.to,
@@ -872,26 +950,28 @@ const livePreviewPlugin = ViewPlugin.fromClass(
         update.selectionSet ||
         update.viewportChanged ||
         syntaxTree(update.state) !== syntaxTree(update.startState) ||
-        // A Compartment reconfigure (live view, remote images, portability
-        // mode, tracked changes — any of them) does NOT recreate this plugin
+        // A Compartment reconfigure (any of them: live view, remote images,
+        // portability mode, tracked changes) does NOT recreate this plugin
         // when the reconfigured extension array still contains this same
         // `livePreviewPlugin` value — CodeMirror's EditorView.updatePlugins
         // finds it by reference in the old spec array and reuses the
         // existing instance rather than constructing a new one. That reused
         // instance still gets its update() called, but none of the four
         // checks above fire for a bare reconfigure, so without this check a
-        // widget whose rendering depends on state outside the document (a
+        // widget whose rendering depends on state outside the document (an
+        // image load that only resolves once currentDocumentPath is set, a
         // remote image only allowed once the setting flips) would keep
         // showing its stale placeholder until something else — an edit, a
         // scroll — happened to touch it. `tr.reconfigured` is public API
         // (`startState.config != state.config`), so this covers every
-        // reconfigure, not just the one that changed.
+        // reconfigure, not just the live-view one.
         //
         // Rebuilding is only half of it: build() constructs a fresh
         // ImageWidget either way, but CodeMirror still decides whether to
         // redraw by comparing it to the previous one via eq() — see the
-        // `remoteBlocked` field on ImageWidget for the other half, without
-        // which a fresh-but-eq()-equal widget would still keep its stale DOM.
+        // `remoteBlocked`/`resolvedLocalPath` fields on ImageWidget for the
+        // other half, without which a fresh-but-eq()-equal widget would
+        // still keep its stale DOM.
         update.transactions.some((tr) => tr.reconfigured)
       ) {
         [this.decorations, this.atomics] = this.build(update.view);

--- a/src/livepreview.ts
+++ b/src/livepreview.ts
@@ -116,18 +116,29 @@ class AdmonitionTitleWidget extends WidgetType {
 }
 
 class ImageWidget extends WidgetType {
+  /** Whether this is a remote image the reader has not opted into loading —
+   * captured at construction, not re-read live in toDOM/eq, because eq()
+   * only ever sees the two widget INSTANCES being compared: if this were a
+   * live `remoteImagesAllowed()` call instead of a field, two widgets built
+   * before and after the setting changed would still compare equal on
+   * url/alt/width and CodeMirror would keep the stale (blocked) DOM instead
+   * of redrawing when the setting flips. */
+  private readonly remoteBlocked: boolean;
+
   constructor(
     readonly url: string,
     readonly alt: string,
     readonly width: string,
   ) {
     super();
+    this.remoteBlocked = isRemoteUrl(url) && !remoteImagesAllowed();
   }
   eq(other: ImageWidget) {
     return (
       other.url === this.url &&
       other.alt === this.alt &&
-      other.width === this.width
+      other.width === this.width &&
+      other.remoteBlocked === this.remoteBlocked
     );
   }
   toDOM(view: EditorView) {
@@ -138,7 +149,7 @@ class ImageWidget extends WidgetType {
     // An <img> with no src draws the browser's broken-image glyph with the alt
     // text struck through it, which reads as an error when nothing is wrong —
     // and there is no image to resize, so the drag handle is skipped too.
-    if (isRemoteUrl(this.url) && !remoteImagesAllowed()) {
+    if (this.remoteBlocked) {
       const blocked = document.createElement("span");
       blocked.className = "cm-image-blocked";
       blocked.dataset.blockedSrc = this.url;
@@ -860,7 +871,28 @@ const livePreviewPlugin = ViewPlugin.fromClass(
         update.docChanged ||
         update.selectionSet ||
         update.viewportChanged ||
-        syntaxTree(update.state) !== syntaxTree(update.startState)
+        syntaxTree(update.state) !== syntaxTree(update.startState) ||
+        // A Compartment reconfigure (live view, remote images, portability
+        // mode, tracked changes — any of them) does NOT recreate this plugin
+        // when the reconfigured extension array still contains this same
+        // `livePreviewPlugin` value — CodeMirror's EditorView.updatePlugins
+        // finds it by reference in the old spec array and reuses the
+        // existing instance rather than constructing a new one. That reused
+        // instance still gets its update() called, but none of the four
+        // checks above fire for a bare reconfigure, so without this check a
+        // widget whose rendering depends on state outside the document (a
+        // remote image only allowed once the setting flips) would keep
+        // showing its stale placeholder until something else — an edit, a
+        // scroll — happened to touch it. `tr.reconfigured` is public API
+        // (`startState.config != state.config`), so this covers every
+        // reconfigure, not just the one that changed.
+        //
+        // Rebuilding is only half of it: build() constructs a fresh
+        // ImageWidget either way, but CodeMirror still decides whether to
+        // redraw by comparing it to the previous one via eq() — see the
+        // `remoteBlocked` field on ImageWidget for the other half, without
+        // which a fresh-but-eq()-equal widget would still keep its stale DOM.
+        update.transactions.some((tr) => tr.reconfigured)
       ) {
         [this.decorations, this.atomics] = this.build(update.view);
       }

--- a/src/localimages.test.ts
+++ b/src/localimages.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+import { loadLocalImage, resolveLocalImagePath } from "./localimages";
+
+describe("resolveLocalImagePath", () => {
+  it("returns an already-absolute reference as-is, regardless of the document", () => {
+    for (const [path, doc] of [
+      ["/etc/hosts", null],
+      ["/etc/hosts", "/home/x/notes.md"],
+      ["C:\\Users\\x\\pic.png", null],
+      ["C:/Users/x/pic.png", "C:\\docs\\note.md"],
+      [String.raw`\\host\share\pic.png`, null],
+      ["//host/share/pic.png", "/a/b.md"],
+    ] as const) {
+      expect(resolveLocalImagePath(path, doc), path).toBe(path);
+    }
+  });
+
+  it("joins a relative reference against the open document's directory", () => {
+    expect(resolveLocalImagePath("img.png", "/home/x/notes.md")).toBe(
+      "/home/x/img.png",
+    );
+    expect(resolveLocalImagePath("./img.png", "/home/x/notes.md")).toBe(
+      "/home/x/img.png",
+    );
+    expect(resolveLocalImagePath("images/img.png", "/home/x/notes.md")).toBe(
+      "/home/x/images/img.png",
+    );
+    expect(resolveLocalImagePath("../img.png", "/home/x/sub/notes.md")).toBe(
+      "/home/x/img.png",
+    );
+    expect(
+      resolveLocalImagePath("..\\assets\\img.png", "C:\\docs\\sub\\note.md"),
+    ).toBe("C:\\docs\\assets\\img.png");
+  });
+
+  it("cannot resolve a relative reference with no open document", () => {
+    expect(resolveLocalImagePath("img.png", null)).toBeNull();
+    expect(resolveLocalImagePath("./img.png", null)).toBeNull();
+  });
+});
+
+// invokeMock is reset at the top of each test body rather than in a
+// beforeEach: resetting it from a hook was observed to make Vitest misreport
+// a properly-handled rejection in a later test as an uncaught error (the
+// mock's async-result tracking gets confused about which test a settled
+// promise belongs to). Resetting inline avoids that.
+describe("loadLocalImage", () => {
+  it("invokes read_image_as_data_url with the resolved path", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("data:image/png;base64,AAAA");
+    const result = await loadLocalImage("/home/x/img-a.png");
+    expect(result).toBe("data:image/png;base64,AAAA");
+    expect(invokeMock).toHaveBeenCalledWith("read_image_as_data_url", {
+      path: "/home/x/img-a.png",
+    });
+  });
+
+  it("calls invoke only once for the same resolved path (cached)", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue("data:image/png;base64,BBBB");
+    const path = "/home/x/img-b.png";
+    const [a, b] = await Promise.all([
+      loadLocalImage(path),
+      loadLocalImage(path),
+    ]);
+    expect(a).toBe(b);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a rejection (e.g. a non-image extension) to the caller", async () => {
+    invokeMock.mockReset();
+    invokeMock.mockRejectedValue(
+      "/home/x/notes.txt is not a supported image type",
+    );
+    await expect(loadLocalImage("/home/x/notes.txt")).rejects.toBe(
+      "/home/x/notes.txt is not a supported image type",
+    );
+  });
+
+  it("does not cache a rejection: the next call for the same path retries", async () => {
+    invokeMock.mockReset();
+    const path = "/home/x/not-there-yet.png";
+
+    invokeMock.mockRejectedValueOnce("ENOENT: no such file");
+    await expect(loadLocalImage(path)).rejects.toBe("ENOENT: no such file");
+
+    // The file has since appeared (or the reference was a typo now fixed) —
+    // a later re-render must not still be looking at the failed promise.
+    invokeMock.mockResolvedValueOnce("data:image/png;base64,DDDD");
+    await expect(loadLocalImage(path)).resolves.toBe(
+      "data:image/png;base64,DDDD",
+    );
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/localimages.ts
+++ b/src/localimages.ts
@@ -80,16 +80,41 @@ export function resolveLocalImagePath(
 // An ordinary edit elsewhere in the document does NOT hit this path, even
 // though `build()` reruns for that too (docChanged): CodeMirror compares the
 // freshly-built ImageWidget against the existing one via eq() — url, alt,
-// width, and (since this file's cache/resolution state is not part of the
-// widget's own fields) two captured-at-construction values, `remoteBlocked`
-// and `resolvedLocalPath`. An unrelated edit changes none of those for this
-// image, so eq() says "same," the old DOM is kept, and toDOM() (therefore
-// loadLocalImage) never reruns. A reconfigure that actually changed
-// getCurrentDocumentPath() or remoteImagesAllowed() DOES change one of those
-// captured values for a widget whose reference depends on it, which is
-// exactly what makes eq() report a difference and forces the redraw this
-// cache is then in place for.
+// width, and (since this module's cache/resolution state is not part of the
+// widget's own fields) three captured-at-construction values, `remoteBlocked`,
+// `resolvedLocalPath`, and `loadFailureCount`. An unrelated edit changes none
+// of those for this image, so eq() says "same," the old DOM is kept, and
+// toDOM() (therefore loadLocalImage) never reruns.
+//
+// A reconfigure that changed getCurrentDocumentPath() or
+// remoteImagesAllowed() changes `resolvedLocalPath`/`remoteBlocked` for a
+// widget whose reference depends on it. But resolving to the SAME path twice
+// is not the only way the outcome can change: a widget built right after a
+// failed load, and one built on the next reconfigure with nothing else
+// different, resolve to the identical path — that retry needs
+// `loadFailureCount` specifically, or eq() would see three matching fields
+// and one unchanged one, call the two widgets equal, and keep showing the
+// stale failure placeholder even after the file starts loading successfully.
 const cache = new Map<string, Promise<string>>();
+
+// Resolved absolute path -> number of loads that have failed for it so far.
+// eq() (ImageWidget, livepreview.ts) cannot tell "the resolved path changed"
+// apart from "the same path just started working" by comparing
+// resolvedLocalPath alone — that field is identical before and after a
+// retry, since the document didn't move, only the file's existence did.
+// This counter is the thing that DOES differ: a widget captures it at
+// construction (see ImageWidget's `loadFailureCount` field), so a widget
+// built right after a failure and one built after the next reconfigure -
+// even at the very same resolved path - compare unequal via eq() until a
+// load actually succeeds, at which point the count stops changing and
+// eq() goes back to treating that path as stable across ordinary edits.
+const failureCount = new Map<string, number>();
+
+/** How many times a load for `resolvedPath` has failed so far (0 if never
+ * attempted or never failed). Read at ImageWidget construction time. */
+export function loadFailureCount(resolvedPath: string): number {
+  return failureCount.get(resolvedPath) ?? 0;
+}
 
 /**
  * Load (and cache) the data: URL for an already-resolved absolute path.
@@ -109,7 +134,10 @@ export function loadLocalImage(resolvedPath: string): Promise<string> {
   if (pending === undefined) {
     pending = invoke<string>("read_image_as_data_url", { path: resolvedPath });
     cache.set(resolvedPath, pending);
-    pending.catch(() => cache.delete(resolvedPath));
+    pending.catch(() => {
+      cache.delete(resolvedPath);
+      failureCount.set(resolvedPath, loadFailureCount(resolvedPath) + 1);
+    });
   }
   return pending;
 }

--- a/src/localimages.ts
+++ b/src/localimages.ts
@@ -1,0 +1,115 @@
+/**
+ * Resolving and loading local (on-disk) image references in the live preview.
+ *
+ * A local reference in a `.md` — `![alt](diagram.png)` or `<img src="../x.png">`
+ * — names a file next to the document, not a URL the webview can fetch itself:
+ * there is no asset-protocol scope and no fs plugin, so the only way to get the
+ * bytes is the `read_image_as_data_url` Tauri command, which returns a
+ * `data:` URL the browser can decode like any other image source.
+ *
+ * This module owns two small, independent things:
+ * - resolving a markdown-relative reference against the open document's path
+ *   (`resolveLocalImagePath`), and
+ * - fetching and caching the resulting data URL (`loadLocalImage`).
+ *
+ * The current document's path is pushed in from `main.ts` whenever it changes
+ * (open, save-as, …) rather than imported directly, the same shape
+ * `remoteimages.ts` uses for the remote-images toggle — it keeps this module
+ * free of any dependency on `main.ts`, which itself imports the live-preview
+ * extension that (transitively) reads from here.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+let currentDocumentPath: string | null = null;
+
+export function setCurrentDocumentPath(path: string | null): void {
+  currentDocumentPath = path;
+}
+
+export function getCurrentDocumentPath(): string | null {
+  return currentDocumentPath;
+}
+
+/** True for a POSIX absolute path (`/x`), a Windows drive path (`C:\x`), a
+ * Windows root-relative path (`\x`), or a UNC/protocol-relative path
+ * (`\\host\share`, `//host/share`) — anything that names a file without
+ * reference to the open document's location. */
+function isAbsoluteLocalPath(path: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(path) || /^[\\/]/.test(path);
+}
+
+/**
+ * Resolve a markdown image reference to an absolute path, or `null` if it
+ * cannot be resolved (a relative reference with no open document to be
+ * relative *to*).
+ *
+ * An already-absolute reference is returned as-is — including a UNC path,
+ * which `read_image_as_data_url` will itself refuse unless the user has
+ * opted into network paths, the same guard `read_file` applies.
+ */
+export function resolveLocalImagePath(
+  url: string,
+  documentPath: string | null,
+): string | null {
+  if (isAbsoluteLocalPath(url)) return url;
+  if (documentPath === null) return null;
+
+  const sep =
+    documentPath.includes("\\") && !documentPath.includes("/") ? "\\" : "/";
+  const dir = documentPath.split(/[\\/]/);
+  dir.pop(); // drop the document's own file name
+
+  for (const segment of url.split(/[\\/]/)) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") dir.pop();
+    else dir.push(segment);
+  }
+  return dir.join(sep);
+}
+
+// Resolved absolute path -> in-flight/completed fetch. Keyed by resolved path
+// rather than the raw markdown reference so two different relative references
+// that land on the same file share one invoke. It also matters across a
+// liveCompartment.reconfigure() (main.ts: saveFile, toggleLiveView,
+// toggleRemoteImages): livePreviewPlugin.update() (livepreview.ts) treats
+// `tr.reconfigured` as a rebuild trigger, so `build()` reruns and constructs
+// a fresh ImageWidget for this file — without this cache, that fresh widget
+// would re-invoke even though the file was already loaded moments ago.
+//
+// An ordinary edit elsewhere in the document does NOT hit this path, even
+// though `build()` reruns for that too (docChanged): CodeMirror compares the
+// freshly-built ImageWidget against the existing one via eq() — url, alt,
+// width, and (since this file's cache/resolution state is not part of the
+// widget's own fields) two captured-at-construction values, `remoteBlocked`
+// and `resolvedLocalPath`. An unrelated edit changes none of those for this
+// image, so eq() says "same," the old DOM is kept, and toDOM() (therefore
+// loadLocalImage) never reruns. A reconfigure that actually changed
+// getCurrentDocumentPath() or remoteImagesAllowed() DOES change one of those
+// captured values for a widget whose reference depends on it, which is
+// exactly what makes eq() report a difference and forces the redraw this
+// cache is then in place for.
+const cache = new Map<string, Promise<string>>();
+
+/**
+ * Load (and cache) the data: URL for an already-resolved absolute path.
+ *
+ * A rejection is NOT cached: unlike a successful load (this module does no
+ * file-watching, so a *changed* file stays stale until the next reconfigure
+ * that changes what this widget resolves to — see the comment on `cache`
+ * above), a failed one commonly means the file does not exist *yet* — a
+ * reference typed before the target is saved or copied into place. Caching
+ * that failure would mean the image never loads for the rest of the session
+ * even after the file appears, until the document is closed and reopened.
+ * Evicting on failure costs an extra invoke per reconfigure for a reference
+ * that stays permanently broken, which is cheap next to what it buys.
+ */
+export function loadLocalImage(resolvedPath: string): Promise<string> {
+  let pending = cache.get(resolvedPath);
+  if (pending === undefined) {
+    pending = invoke<string>("read_image_as_data_url", { path: resolvedPath });
+    cache.set(resolvedPath, pending);
+    pending.catch(() => cache.delete(resolvedPath));
+  }
+  return pending;
+}

--- a/src/localimages.ts
+++ b/src/localimages.ts
@@ -108,6 +108,17 @@ const cache = new Map<string, Promise<string>>();
 // even at the very same resolved path - compare unequal via eq() until a
 // load actually succeeds, at which point the count stops changing and
 // eq() goes back to treating that path as stable across ordinary edits.
+//
+// Uncapped and unthrottled by design, with a known consequence: a
+// permanently-broken reference (typo, moved file) retries on every single
+// reconfigure for as long as the count keeps incrementing, and with
+// autosave on and active typing that's saveFile firing every ~1.5s idle
+// gap — a continuous retry every ~1.5 seconds for the rest of the editing
+// session, not an occasional check. Each retry is cheap (one IPC round
+// trip, a fast ENOENT), and the alternative — capping retries — would
+// bring back the exact problem this file exists to avoid: a file that
+// shows up later never loading without closing and reopening the
+// document. Accepted trade-off, not an oversight.
 const failureCount = new Map<string, number>();
 
 /** How many times a load for `resolvedPath` has failed so far (0 if never

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import { createDocumentState, serializeDocument } from "./document";
 import { applyMeta, parseMeta, type DocMeta, type MetaFormat } from "./meta";
 import { PortabilityMode, portabilityExtensions } from "./portability";
 import { livePreviewExtensions } from "./livepreview";
+import { setCurrentDocumentPath } from "./localimages";
 import {
   applyLink,
   changeCase,
@@ -1892,6 +1893,13 @@ function loadIntoEditor(
   path: string | null,
   suggested: string | null = null,
 ) {
+  // Pushed before setState, not after: setState synchronously rebuilds the
+  // live-preview decorations (ViewPlugin.fromClass's constructor runs
+  // immediately), which is where local image references get resolved
+  // against this path. Setting it after would resolve the new document's
+  // images against the *previous* document's directory (or null, on the
+  // first file opened this session).
+  setCurrentDocumentPath(path);
   // A fresh state per file so the lineSeparator facet matches the file's
   // actual line endings (the facet is fixed at state creation).
   view.setState(createDocumentState(content, editorExtensions()));
@@ -2062,6 +2070,17 @@ async function saveFile(forcePrompt = false): Promise<boolean> {
       await invoke("write_file", { path, contents });
     }
     currentPath = path;
+    setCurrentDocumentPath(path);
+    // A document saved for the first time (or saved-as to a new directory)
+    // can turn previously unresolvable relative image references into
+    // resolvable ones. Same reconfigure toggleRemoteImages uses: an image
+    // widget caches its DOM, so a placeholder keeps showing until the
+    // decorations are rebuilt.
+    view.dispatch({
+      effects: liveCompartment.reconfigure(
+        liveView ? livePreviewExtensions() : rawViewExtensions,
+      ),
+    });
     // The document has a real name now, so any imported suggestion is spent.
     suggestedName = null;
     dirty = false;


### PR DESCRIPTION
## Summary
- Local/relative image references (`![alt](diagram.png)`, `<img src="../x.png">`) now render in the live preview instead of always falling back to alt text. New Tauri command `read_image_as_data_url` reads the file and hands back a `data:` URL; `src/localimages.ts` resolves the reference against the open document's path and caches the result.
- Fixes a pre-existing, unrelated bug found along the way: toggling "Load remote images" while already in live view didn't actually clear already-blocked image placeholders, because reconfiguring a Compartment to a referentially-identical extension reuses the existing `ViewPlugin` instance rather than reconstructing it, and `ImageWidget.eq()` didn't account for that. Fixed by treating `Transaction.reconfigured` as a rebuild trigger and capturing the relevant live state (`remoteBlocked`, `resolvedLocalPath`, `loadFailureCount`) on the widget so `eq()` actually notices when it should redraw.
- A failed local-image load is not cached, so a reference typed before its target exists retries on the next reconfigure (save, live-view toggle, etc.) instead of staying broken for the rest of the session. This is intentionally uncapped/unthrottled — documented as an accepted trade-off, not an oversight — since capping retries would reintroduce the exact problem it exists to avoid.

## Commits
1. `fix(livepreview): rebuild image widgets across any compartment reconfigure` — the pre-existing `toggleRemoteImages` bug, isolated with its own regression test against unmodified logic.
2. `feat(livepreview): render local (on-disk) images in the live preview` — the feature itself.
3. `fix(localimages): retry a failed local-image load after a reconfigure` — closes a gap the previous eq() fix didn't cover (same resolved path, changed outcome).
4. `docs(localimages): note the uncapped-retry consequence on loadFailureCount` — names the autosave-driven continuous-retry consequence explicitly.

## Test plan
- [x] `cargo test` — 67/67 unit + 13/13 PDF integration tests, `cargo fmt`/`clippy` clean
- [x] `npx vitest run` — 566/566 frontend tests (30 files)
- [x] `npx tsc --noEmit`, `eslint`, `prettier --check` clean
- [x] Manual: built and ran the real dev binary, opened a document with a relative local image reference, confirmed it rendered (screenshot-verified)
- [ ] Reviewer: confirm the accepted continuous-retry-during-autosave trade-off documented in `localimages.ts` is acceptable