### PR TITLE
Add Browse button/drag-and-drop for local images, fix path escaping

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,7 +612,7 @@
               <button
                 id="btn-image"
                 class="icon-btn"
-                title="Insert image by URL"
+                title="Insert image (URL or local file — you can also drag and drop a file)"
                 aria-label="Insert image"
               >
                 <svg class="icon"><use href="#i-image" /></svg>
@@ -1036,14 +1036,19 @@
     <dialog id="image-dialog" class="ml-dialog">
       <form method="dialog">
         <label for="image-url"
-          >Image URL (the picture stays at this address, not in the file)</label
+          >Image URL or local file path (a URL stays at that address; a local
+          file's bytes are read fresh each time the document is opened, never
+          copied into it)</label
         >
-        <input
-          id="image-url"
-          type="text"
-          placeholder="https://"
-          spellcheck="false"
-        />
+        <div class="ml-image-url-row">
+          <input
+            id="image-url"
+            type="text"
+            placeholder="https:// or a local file"
+            spellcheck="false"
+          />
+          <button id="image-browse" type="button">Browse…</button>
+        </div>
         <label for="image-alt">Alt text (optional)</label>
         <input id="image-alt" type="text" spellcheck="false" />
         <menu>

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -184,6 +184,25 @@ describe("inline toggles", () => {
     );
     expect(imageMarkup("https://x/y.png", "")).toBe("![](https://x/y.png)");
   });
+
+  it("wraps a destination containing a space or parenthesis in <...>", () => {
+    // A bare CommonMark destination can't contain either — the parser stops
+    // there, and the whole ![]() silently fails to become an image at all
+    // (see livepreview.test.ts). Both are ordinary in real Windows paths:
+    // "OneDrive - Some Company" and "Screenshot (1).png".
+    expect(imageMarkup("C:\\Users\\x\\OneDrive - Co\\pic.png", "pic")).toBe(
+      "![pic](<C:\\Users\\x\\OneDrive - Co\\pic.png>)",
+    );
+    expect(imageMarkup("C:\\Users\\x\\pic (1).png", "pic")).toBe(
+      "![pic](<C:\\Users\\x\\pic (1).png>)",
+    );
+  });
+
+  it("leaves a destination with neither a space nor a parenthesis bare", () => {
+    expect(imageMarkup("images/diagram.png", "d")).toBe(
+      "![d](images/diagram.png)",
+    );
+  });
 });
 
 describe("underline and highlight (inline HTML)", () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -297,9 +297,19 @@ export const insertMath: StateCommand = ({ state, dispatch }) => {
 /**
  * Portable markdown image reference: ![alt](url). Renders in the editor, the
  * PDF, and on GitHub; the pixels stay at the URL, never inside the .md.
+ *
+ * A bare (unbracketed) CommonMark link destination cannot contain a space or
+ * a parenthesis — parsing stops there, so the rest (and the whole construct)
+ * silently fails to become an image at all and is left as plain text. Local
+ * file paths hit this constantly: "OneDrive - Some Company" and
+ * "Screenshot (1).png" are both completely ordinary Windows names. Wrapping
+ * the destination in `<...>` is the CommonMark-standard escape hatch for
+ * exactly this — every compliant renderer (GitHub included) treats
+ * `(<url>)` and `(url)` identically when `url` needs no escaping.
  */
 export function imageMarkup(url: string, alt: string): string {
-  return `![${alt}](${url})`;
+  const destination = /[\s()]/.test(url) ? `<${url}>` : url;
+  return `![${alt}](${destination})`;
 }
 
 /**

--- a/src/livepreview.test.ts
+++ b/src/livepreview.test.ts
@@ -86,6 +86,47 @@ describe("no raw-syntax bleeds", () => {
     ]);
   });
 
+  /** The widget's own `url` field (decos() only reports whether a range is a
+   * widget, not what it's for) — for verifying a wrapped destination gets
+   * unwrapped, and a bare one that needed wrapping produces nothing at all. */
+  function widgetUrls(doc: string): string[] {
+    const state = EditorState.create({
+      doc,
+      extensions: markdownForMode("enhanced"),
+    });
+    const tree = ensureSyntaxTree(state, doc.length, 5000)!;
+    const set = buildLivePreviewDecorations(state, 0, doc.length, tree);
+    const urls: string[] = [];
+    const it = set.decorations.iter();
+    while (it.value !== null) {
+      const spec = it.value.spec as { widget?: { url?: string } };
+      if (spec.widget?.url !== undefined) urls.push(spec.widget.url);
+      it.next();
+    }
+    return urls;
+  }
+
+  it("unwraps a <...>-wrapped destination (a space or parenthesis, imageMarkup's escape hatch)", () => {
+    expect(
+      widgetUrls("![pic](<C:\\Users\\x\\OneDrive - Co\\pic.png>)"),
+    ).toEqual(["C:\\Users\\x\\OneDrive - Co\\pic.png"]);
+    expect(widgetUrls("![pic](<C:\\Users\\x\\pic (1).png>)")).toEqual([
+      "C:\\Users\\x\\pic (1).png",
+    ]);
+  });
+
+  it("renders nothing for a bare destination containing a space or parenthesis", () => {
+    // Invalid CommonMark, not a Monoleaf gap: a bare (unbracketed)
+    // destination can't contain either, so the parser only recognises
+    // "![alt]" and leaves the rest as plain text — there is no image node
+    // to hand ImageWidget at all. imageMarkup (commands.ts) never produces
+    // this; it's only reachable by hand-typing an unwrapped path.
+    expect(widgetUrls("![pic](C:\\Users\\x\\OneDrive - Co\\pic.png)")).toEqual(
+      [],
+    );
+    expect(widgetUrls("![pic](C:\\Users\\x\\pic (1).png)")).toEqual([]);
+  });
+
   it("hides a setext underline and sizes the heading", () => {
     const doc = "Title\n=====\n\nbody";
     const all = decos(doc, doc.length);

--- a/src/livepreview.ts
+++ b/src/livepreview.ts
@@ -312,7 +312,11 @@ function commitImageWidth(
 ): void {
   const pos = view.posAtDOM(dom);
   const line = view.state.doc.lineAt(pos);
-  const re = /!\[[^\]]*\]\([^)]*\)|<img\b[^>]*>/gi;
+  // The image case's destination may be <...>-wrapped (imageMarkup,
+  // commands.ts, for a path containing a space or parenthesis) — that
+  // wrapped form can itself contain a literal ")", so the bare `[^)]*`
+  // alternative alone would stop matching partway through it.
+  const re = /!\[[^\]]*\]\((?:<[^>]*>|[^)]*)\)|<img\b[^>]*>/gi;
   for (const m of line.text.matchAll(re)) {
     const from = line.from + (m.index ?? 0);
     const to = from + m[0].length;
@@ -323,7 +327,14 @@ function commitImageWidth(
     if (t.startsWith("![")) {
       const c = t.indexOf("](");
       alt = t.slice(2, c);
-      src = t.slice(c + 2, t.length - 1).split(/\s+/)[0];
+      const dest = t.slice(c + 2, t.length - 1);
+      // <...>-wrapped: take everything up to the matching >, same as the
+      // Image case (livepreview's buildLivePreviewDecorations) does via the
+      // parser's URL node. Bare: stop at the first space, which is how a
+      // trailing "title" gets dropped (unsupported here, same as before).
+      src = dest.startsWith("<")
+        ? dest.slice(1, dest.indexOf(">"))
+        : dest.split(/\s+/)[0];
     } else {
       src =
         /\bsrc\s*=\s*"([^"]*)"/.exec(t)?.[1] ??
@@ -579,11 +590,28 @@ export function buildLivePreviewDecorations(
           // Every reference gets a widget; the .md itself still holds only
           // the reference, never image bytes — ImageWidget decides how to
           // get from that reference to pixels (or a placeholder).
-          const text = state.doc.sliceString(node.from, node.to);
-          const close = text.indexOf("](");
-          if (text.startsWith("![") && close >= 0) {
-            const alt = text.slice(2, close);
-            const url = text.slice(close + 2, text.length - 1).split(/\s+/)[0];
+          //
+          // Read the destination from the parser's own URL child (same
+          // approach as the Link case below) rather than slicing the raw
+          // text and splitting on whitespace: a destination containing a
+          // space or a title ("img.png "a title"") makes naive splitting cut
+          // it short, and — more importantly — a bare destination
+          // containing a space or parenthesis (an ordinary Windows path
+          // like "OneDrive - Some Company\pic.png") isn't valid CommonMark
+          // at all, so the parser only recognises "![alt]" and leaves the
+          // rest as plain text; there is no "](url)" tail here to slice in
+          // the first place. imageMarkup() (commands.ts) wraps such
+          // destinations in `<...>`, which the parser DOES recognise as a
+          // whole Image — getChild("URL") includes those angle brackets in
+          // its text, so they're stripped here.
+          const urlNode = node.node.getChild("URL");
+          const marks = node.node.getChildren("LinkMark");
+          if (urlNode !== null && marks.length >= 2) {
+            const alt = state.sliceDoc(marks[0].to, marks[1].from);
+            let url = state.sliceDoc(urlNode.from, urlNode.to);
+            if (url.startsWith("<") && url.endsWith(">")) {
+              url = url.slice(1, -1);
+            }
             hideRange(
               node.from,
               node.to,

--- a/src/localimages.test.ts
+++ b/src/localimages.test.ts
@@ -49,9 +49,9 @@ describe("resolveLocalImagePath", () => {
 
 describe("relativizeUnderDocument", () => {
   it("rewrites a path under the document's own directory as relative", () => {
-    expect(
-      relativizeUnderDocument("/home/x/img.png", "/home/x/notes.md"),
-    ).toBe("img.png");
+    expect(relativizeUnderDocument("/home/x/img.png", "/home/x/notes.md")).toBe(
+      "img.png",
+    );
     expect(
       relativizeUnderDocument("/home/x/assets/img.png", "/home/x/notes.md"),
     ).toBe("assets/img.png");
@@ -62,10 +62,7 @@ describe("relativizeUnderDocument", () => {
 
   it("uses / regardless of the document's own separator style", () => {
     expect(
-      relativizeUnderDocument(
-        "C:\\docs\\assets\\img.png",
-        "C:\\docs\\note.md",
-      ),
+      relativizeUnderDocument("C:\\docs\\assets\\img.png", "C:\\docs\\note.md"),
     ).toBe("assets/img.png");
   });
 

--- a/src/localimages.test.ts
+++ b/src/localimages.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 
-import { loadLocalImage, resolveLocalImagePath } from "./localimages";
+import {
+  loadLocalImage,
+  relativizeUnderDocument,
+  resolveLocalImagePath,
+} from "./localimages";
 
 describe("resolveLocalImagePath", () => {
   it("returns an already-absolute reference as-is, regardless of the document", () => {
@@ -40,6 +44,46 @@ describe("resolveLocalImagePath", () => {
   it("cannot resolve a relative reference with no open document", () => {
     expect(resolveLocalImagePath("img.png", null)).toBeNull();
     expect(resolveLocalImagePath("./img.png", null)).toBeNull();
+  });
+});
+
+describe("relativizeUnderDocument", () => {
+  it("rewrites a path under the document's own directory as relative", () => {
+    expect(
+      relativizeUnderDocument("/home/x/img.png", "/home/x/notes.md"),
+    ).toBe("img.png");
+    expect(
+      relativizeUnderDocument("/home/x/assets/img.png", "/home/x/notes.md"),
+    ).toBe("assets/img.png");
+    expect(
+      relativizeUnderDocument("C:\\docs\\img.png", "C:\\docs\\note.md"),
+    ).toBe("img.png");
+  });
+
+  it("uses / regardless of the document's own separator style", () => {
+    expect(
+      relativizeUnderDocument(
+        "C:\\docs\\assets\\img.png",
+        "C:\\docs\\note.md",
+      ),
+    ).toBe("assets/img.png");
+  });
+
+  it("falls back to null (caller keeps the absolute path) when not under the document's directory", () => {
+    // A sibling directory: not a prefix match, even though both are under /home/x.
+    expect(
+      relativizeUnderDocument("/home/x/other/img.png", "/home/x/sub/notes.md"),
+    ).toBeNull();
+    // A different drive entirely.
+    expect(
+      relativizeUnderDocument("D:\\img.png", "C:\\docs\\note.md"),
+    ).toBeNull();
+    // The path IS the document's directory (no file name left to reference).
+    expect(relativizeUnderDocument("/home/x", "/home/x/notes.md")).toBeNull();
+  });
+
+  it("cannot relativize with no open document", () => {
+    expect(relativizeUnderDocument("/home/x/img.png", null)).toBeNull();
   });
 });
 

--- a/src/localimages.ts
+++ b/src/localimages.ts
@@ -68,6 +68,52 @@ export function resolveLocalImagePath(
   return dir.join(sep);
 }
 
+/**
+ * Rewrite an absolute path as relative to the open document's directory, or
+ * return it unchanged if it isn't under that directory (a different drive,
+ * a sibling folder, or no open document at all).
+ *
+ * Deliberately does not escape upward with `../..` to reach a common
+ * ancestor outside the document's own directory tree: the payoff (a shorter
+ * reference) is small, and "must be inside the document's folder or its
+ * subfolders" is a simple, unsurprising rule for what a picked/dropped image
+ * turns into, instead of a reference that silently depends on exactly how
+ * far apart two folders happen to sit.
+ */
+export function relativizeUnderDocument(
+  absolutePath: string,
+  documentPath: string | null,
+): string | null {
+  if (documentPath === null) return null;
+
+  const dir = documentPath.split(/[\\/]/);
+  dir.pop(); // drop the document's own file name
+  const target = absolutePath.split(/[\\/]/);
+
+  for (let i = 0; i < dir.length; i++) {
+    if (dir[i] !== target[i]) return null; // not under the document's directory
+  }
+  const rest = target.slice(dir.length);
+  if (rest.length === 0) return null; // the path IS the document's directory
+  return rest.join("/"); // "/" regardless of platform: markdown convention,
+  // and the document may later be opened on a different OS.
+}
+
+/** Extensions `read_image_as_data_url` (src-tauri/src/lib.rs, `image_mime_type`)
+ * accepts. Duplicated here rather than queried from Rust: it's a short,
+ * closed, rarely-changing list, and both the file-picker filter and the
+ * drag-and-drop filter need it synchronously, before any invoke. */
+export const IMAGE_EXTENSIONS = [
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "avif",
+];
+
 // Resolved absolute path -> in-flight/completed fetch. Keyed by resolved path
 // rather than the raw markdown reference so two different relative references
 // that land on the same file share one invoke. It also matters across a

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { Compartment, Prec, StateCommand } from "@codemirror/state";
 import { Channel, invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { readText, writeText } from "@tauri-apps/plugin-clipboard-manager";
@@ -24,7 +25,11 @@ import { createDocumentState, serializeDocument } from "./document";
 import { applyMeta, parseMeta, type DocMeta, type MetaFormat } from "./meta";
 import { PortabilityMode, portabilityExtensions } from "./portability";
 import { livePreviewExtensions } from "./livepreview";
-import { setCurrentDocumentPath } from "./localimages";
+import {
+  IMAGE_EXTENSIONS,
+  relativizeUnderDocument,
+  setCurrentDocumentPath,
+} from "./localimages";
 import {
   applyLink,
   changeCase,
@@ -177,6 +182,11 @@ const MARKDOWN_FILTERS = [
 
 // Import targets: formats converted to Markdown rather than opened as-is.
 const IMPORT_FILTERS = [{ name: "PDF", extensions: ["pdf"] }];
+
+// Browse-for-an-image target (Insert Image dialog, and the extension check on
+// a drag-and-drop). Kept in sync with IMAGE_EXTENSIONS (localimages.ts),
+// which is itself kept in sync with lib.rs's image_mime_type.
+const IMAGE_FILTERS = [{ name: "Images", extensions: IMAGE_EXTENSIONS }];
 
 let currentPath: string | null = null;
 let dirty = false;
@@ -875,6 +885,69 @@ async function insertImage() {
   }
   view.focus();
 }
+
+/** A file's name with its extension stripped, for a default alt-text guess
+ * ("diagram.png" -> "diagram"). Falls back to the whole name for a
+ * dotfile-style name with no extension to strip. */
+function baseNameWithoutExtension(path: string): string {
+  const name = path.split(/[\\/]/).pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}
+
+const imageBrowseButton = document.getElementById(
+  "image-browse",
+) as HTMLButtonElement;
+imageBrowseButton.addEventListener("click", () => void browseForImage());
+
+/** Browse… in the Insert Image dialog: fills in the URL field with a picked
+ * file's path (relative to the open document when possible) without closing
+ * the dialog — the user still confirms with Insert, same as typing it by
+ * hand. */
+async function browseForImage() {
+  const path = await open({ filters: IMAGE_FILTERS, multiple: false });
+  if (path === null) return;
+  imageUrlInput.value = relativizeUnderDocument(path, currentPath) ?? path;
+  if (imageAltInput.value.trim() === "") {
+    imageAltInput.value = baseNameWithoutExtension(path);
+  }
+}
+
+// Dropping a file onto the window: Tauri's native drag-drop (paths, not
+// browser File objects, so this works the same way read_image_as_data_url
+// does — no asset-protocol scope or fs plugin needed). Registered once for
+// the window's lifetime; every dropped path that isn't a recognised image
+// extension is silently ignored; a doc position outside the editor (e.g. a
+// drop on the toolbar) falls back to the current cursor.
+void getCurrentWebview().onDragDropEvent((event) => {
+  if (event.payload.type !== "drop") return;
+  const imagePaths = event.payload.paths.filter((p) =>
+    IMAGE_EXTENSIONS.some((ext) => p.toLowerCase().endsWith(`.${ext}`)),
+  );
+  if (imagePaths.length === 0) return;
+
+  const ratio = window.devicePixelRatio || 1;
+  const pos =
+    view.posAtCoords({
+      x: event.payload.position.x / ratio,
+      y: event.payload.position.y / ratio,
+    }) ?? view.state.selection.main.head;
+
+  const markdown = imagePaths
+    .map((p) =>
+      imageMarkup(
+        relativizeUnderDocument(p, currentPath) ?? p,
+        baseNameWithoutExtension(p),
+      ),
+    )
+    .join("\n");
+  view.dispatch({
+    changes: { from: pos, insert: markdown },
+    selection: { anchor: pos + markdown.length },
+    userEvent: "input.image",
+  });
+  view.focus();
+});
 
 // --- comments ---------------------------------------------------------------
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1874,8 +1874,35 @@ html.theme-dark #editor .cm-cursor {
 
 .ml-dialog input + label,
 .ml-dialog select + label,
-.ml-dialog textarea + label {
+.ml-dialog textarea + label,
+.ml-image-url-row + label {
   margin-top: 12px;
+}
+
+.ml-image-url-row {
+  display: flex;
+  gap: 8px;
+}
+
+.ml-image-url-row input {
+  flex: 1;
+  min-width: 0; /* let the input shrink below its content's natural width */
+}
+
+.ml-image-url-row button {
+  font: inherit;
+  font-size: 13px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ml-image-url-row button:hover {
+  background: var(--hover);
 }
 
 .ml-dialog menu {


### PR DESCRIPTION
## Summary
Follow-up to #51 (local image rendering). Two commits:

1. `feat(main): add a Browse button and drag-and-drop for local images` — the Insert Image dialog now has a Browse… button that opens Tauri's native file picker (filtered to image extensions) and fills in the path (relative to the open document when possible). Dropping one or more image files onto the window also inserts a reference at the drop position, via Tauri's native drag-drop (real filesystem paths, not the browser File API).
2. `fix(commands,livepreview): escape image paths with a space or parenthesis` — found live-testing commit 1 against a real path (`OneDrive - Some Company\pic.jpg`), but it's a general bug, not specific to Browse/drag-drop: a bare `![alt](path)` destination containing a space or parenthesis is invalid CommonMark, and the parser silently drops the whole construct back to plain text instead of recognizing it as an image — confirmed via direct syntax-tree dumps before writing the fix. `imageMarkup` now wraps such a destination in `<...>` (the CommonMark-standard escape), and the parsing side (both the live decoration and the drag-to-resize handle) now reads the parser's own URL node instead of naively slicing text.

## Test plan
- [x] `npx vitest run` — 574/574 (30 files), including new cases for both commits
- [x] `npx tsc --noEmit`, eslint, prettier clean
- [x] Manual: Insert Image dialog renders the Browse button and native file picker with the correct image filter
- [x] Manual (reported by repo owner): Browse and drag-and-drop both work end-to-end, including a real OneDrive path with a space in it