### PR TITLE
fix(macos): use native window chrome instead of the Windows-style title bar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,19 +61,23 @@ fn spawn_document_window(app: &AppHandle, payload: Option<String>) -> Result<Str
             .unwrap_or_else(|e| e.into_inner())
             .insert(label.clone(), p);
     }
-    // Same chrome AND same launch state as the main window (see
-    // tauri.conf.json): our own title bar (decorations off) and maximized, so a
-    // window spawned by New / Open / a file-association launch opens full-screen
-    // like the config-defined "main" window rather than as a small floating box.
-    // inner_size is the restored (un-maximized) size the window falls back to.
-    let win = WebviewWindowBuilder::new(app, &label, WebviewUrl::App("index.html".into()))
+    // Same chrome AND same launch state as the main window (see tauri.conf.json
+    // / tauri.macos.conf.json): our own title bar, maximized, everywhere except
+    // macOS, where a spawned window instead gets native decorations and a
+    // normal (not maximized) size — matching the platform override for the
+    // config-defined "main" window, because a window builder call like this
+    // one is NOT covered by the JSON config merge and would otherwise revert a
+    // New/Open window to the Windows-style chrome on Mac. inner_size is the
+    // restored (un-maximized) size the window falls back to.
+    let builder = WebviewWindowBuilder::new(app, &label, WebviewUrl::App("index.html".into()))
         .title("Monoleaf")
         .inner_size(1000.0, 720.0)
-        .maximized(true)
-        .decorations(false)
-        .focused(true)
-        .build()
-        .map_err(|e| e.to_string())?;
+        .focused(true);
+    #[cfg(target_os = "macos")]
+    let builder = builder.maximized(false).decorations(true);
+    #[cfg(not(target_os = "macos"))]
+    let builder = builder.maximized(true).decorations(false);
+    let win = builder.build().map_err(|e| e.to_string())?;
     // Windows can otherwise place the new window behind the current foreground
     // window; force it to the front so New / Open always surfaces the document.
     let _ = win.set_focus();

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Monoleaf",
+        "width": 1100,
+        "height": 750,
+        "maximized": false,
+        "decorations": true
+      }
+    ]
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,14 @@ import { EditorView, keymap } from "@codemirror/view";
 // Imported first so every face is on document.fonts before the first
 // pagination pass — see ./fontfaces for why the ordering matters.
 import "./fontfaces";
+
+// macOS gets native window decorations (see tauri.macos.conf.json), so our
+// Windows-style custom title bar — and its min/maximize/close buttons, which
+// would otherwise sit duplicated under the real traffic lights — only belongs
+// on the platforms where decorations are off. navigator.platform is reliable
+// here: this always runs inside Tauri's own webview (WKWebView on Mac), never
+// an arbitrary browser, so there's no user-agent spoofing to worry about.
+const isMacOS = navigator.platform.toUpperCase().startsWith("MAC");
 import { editorSetup, rawViewExtensions } from "./setup";
 import { Compartment, Prec, StateCommand } from "@codemirror/state";
 import { Channel, invoke } from "@tauri-apps/api/core";
@@ -236,8 +244,14 @@ function setDirty(value: boolean) {
 
 // Custom title bar: native decorations are off, so the min/maximize/close
 // buttons drive the window directly. The maximize glyph swaps to a restore
-// glyph whenever the window is maximized.
+// glyph whenever the window is maximized. On macOS decorations are on
+// instead (real traffic lights), so this bar would just duplicate them —
+// hide it and skip wiring buttons that aren't there.
 function setupWindowControls() {
+  if (isMacOS) {
+    document.getElementById("titlebar")?.setAttribute("hidden", "");
+    return;
+  }
   const win = getCurrentWindow();
   const maxBtn = document.getElementById("win-max");
   document


### PR DESCRIPTION
## Summary
- A reviewer's Mac feedback: the DMG shipped the same borderless, Windows-style custom title bar (square min/max/close, no traffic lights) and forced full-screen launch, because `decorations: false` / `maximized: true` in `tauri.conf.json` applied to every platform.
- Add `src-tauri/tauri.macos.conf.json` (Tauri auto-merges this on macOS builds only) to restore native decorations and a normal window size on Mac.
- Apply the same platform split in `spawn_document_window` (New/Open windows are built directly in Rust, so they aren't covered by the JSON config merge).
- Hide the custom HTML title bar on macOS in the frontend so it doesn't duplicate the real native one.
- Also noted in the reviewer feedback: Cmd+S appeared not to work. The shortcut handling already treats `metaKey`/`ctrlKey` as equivalent everywhere (predates the macOS build), so there's nothing to fix in that code directly — this is plausibly a symptom of the same undecorated-window setup (known Tauri/WKWebView keyboard-focus quirks on borderless macOS windows), which this PR may resolve as a side effect.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 574/574 passing
- [x] `eslint .` clean
- [x] `prettier --check` clean on changed files
- [x] `cargo check` / `cargo clippy -D warnings` / `cargo fmt --check` clean
- [ ] Build and run the macOS `.dmg` to confirm native traffic lights, normal launch size, and that Cmd+S now works (no Mac available to verify locally — needs a real machine or the CI-built artifact)